### PR TITLE
Link EGI documentation related to notebooks in 401 page

### DIFF
--- a/templates/401.html
+++ b/templates/401.html
@@ -5,15 +5,17 @@
 
 <div class="error">
  <h1>
-    Unauthorised!
+    Unauthorized!
   </h1>
   <p>
     You are trying to access a restricted instance of EGI Notebooks service. If you are interested in accessing or
-    think you should be granted acess already, please open an issue in <a href="https://ggus.eu">GGUS</a>
+    think you should be granted access already, please open an issue in <a href="https://ggus.eu">GGUS</a>
   </p>
 
   <p>
-    You can test the service using the <a href="https://notebooks.egi.eu">EGI Notebooks catch-all instance</a>.
+    You can test the service using the <a href="https://notebooks.egi.eu">EGI Notebooks catch-all instance</a>. See <a href="https://docs.egi.eu/users/notebooks/#service-modes">Documentation related to EGI Notebooks</a> about granting access.
+  </p>
+  <p>
     You can also <a href="https://marketplace.egi.eu/applications-on-demand-beta/65-jupyter.html">place an order in EGI Marketplace</a>
     for the Notebooks service if you are interested in your own community deployment.
   </p>


### PR DESCRIPTION
# Summary

Direct link to [Notebooks#Service Modes](https://docs.egi.eu/users/notebooks/#service-modes) in 401 error page to be more easy for users to get information about granting access, when rejected.

Also minor spellcheck fixes.

I'm not sure about the "Unauthorised" word. It is not in the en_US dictionary (using hunspell), so I modified it too. But maybe it is typically used and would be OK?

---
**Related issue :** https://jira.egi.eu/browse/IMSCHM-58
