### PR TITLE
Updated limits for default resources allocated per user - storage

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -47,7 +47,7 @@
     </p>
     <p>
     Individual users can directly login by clicking the button below. The notebooks are
-    limited to 2 CPU, 4GB RAM and 10GB of persistent storage per user.
+    limited to 2 CPU, 4GB RAM and 20GB of persistent storage per user.
     </p>
     <div class="spacer-sm"></div>
     <p class="text-center">


### PR DESCRIPTION
# Summary

The storage has been also increased from 10GB to 20 GB per user.

**Related issue :**
https://github.com/EGI-Federation/egi-notebooks-hub/pull/58