### PR TITLE
Add a new onedata_failsafe option

### DIFF
--- a/egi_notebooks_hub/onedata.py
+++ b/egi_notebooks_hub/onedata.py
@@ -45,7 +45,7 @@ class OnedataAuthenticator(EGICheckinAuthenticator):
     map_users = Bool(False, config=True, help="""perform mapping""")
 
     onedata_failsafe = Bool(
-        True, config=True, help="""do not fail of onedata is not responsive"""
+        True, config=True, help="""do not fail if onedata is not responsive"""
     )
 
     oneclient_token_name = Unicode(

--- a/egi_notebooks_hub/onedata.py
+++ b/egi_notebooks_hub/onedata.py
@@ -44,6 +44,10 @@ class OnedataAuthenticator(EGICheckinAuthenticator):
 
     map_users = Bool(False, config=True, help="""perform mapping""")
 
+    onedata_failsafe = Bool(
+        True, config=True, help="""do not fail of onedata is not responsive"""
+    )
+
     oneclient_token_name = Unicode(
         "oneclient.notebooks.egi.eu",
         config=True,
@@ -79,6 +83,8 @@ class OnedataAuthenticator(EGICheckinAuthenticator):
         except HTTPError as e:
             if e.code != 404:
                 self.log.info("Something failed! %s", e)
+                if self.onedata_failsafe:
+                    return onedata_token, onedata_user
                 raise e
         if not onedata_token:
             # we don't have a token, create one
@@ -99,6 +105,8 @@ class OnedataAuthenticator(EGICheckinAuthenticator):
                 onedata_token = datahub_response["token"]
             except HTTPError as e:
                 self.log.info("Something failed! %s", e)
+                if self.onedata_failsafe:
+                    return onedata_token, onedata_user
                 raise e
             # Finally get the user information
             req = HTTPRequest(
@@ -112,6 +120,8 @@ class OnedataAuthenticator(EGICheckinAuthenticator):
                 onedata_user = datahub_response["userId"]
             except HTTPError as e:
                 self.log.info("Something failed! %s", e)
+                if self.onedata_failsafe:
+                    return onedata_token, onedata_user
                 raise e
         return onedata_token, onedata_user
 
@@ -149,7 +159,7 @@ class OnedataAuthenticator(EGICheckinAuthenticator):
         if not auth_state:
             # auth_state not enabled
             return
-        if self.map_users:
+        if self.map_users and auth_state.get("onedata_user", None):
             if self.onepanel_url:
                 map_url = self.onepanel_url
             else:


### PR DESCRIPTION
So the datahub does not fail when starting

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->
Avoid failing whenever datahub is not available. 

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :** #75
