### PR TITLE
Filter profiles + annotation of the primary group for accounting

### DIFF
--- a/egi_notebooks_hub/onedata.py
+++ b/egi_notebooks_hub/onedata.py
@@ -286,6 +286,7 @@ class OnedataSpawner(EGISpawner):
     extra_mounts = List([], config=True, help="""extra volume mounts in k8s""")
 
     def auth_state_hook(self, spawner, auth_state):
+        super().auth_state_hook(spawner, auth_state)
         # get onedata stuff ready to be used later on
         if auth_state is None:
             self.log.warning("No auth_state provided")


### PR DESCRIPTION
# Summary

Filter profiles and annotate a primary group. The code is separated between authentication (picking groups) and the spawner (performing profile filtering and annotating the primary group).

## Filter out profiles

Filter out profiles depending on the VO membership of the user.

Those profiles where `vo_claims` is defined (List of strings), they will only be shown as options if the user has any of those exact claims in their entitlements.

Example:
```
profileList:
  - display_name: 'Only for access VO'
    vo_claims:
    - urn:mace:egi.eu:group:vo.access.egi.eu:role=member#aai.egi.eu
    kubespawner_override:
      image: 'eginotebooks/single-user-d4science:sha-8ce52e1'
      cpu_limit: 1
      mem_limit: 1G
```

## Select primary group and annotate

The primary group is selected from the user claims - the first occurrence in the `Authenticator.allowed_groups` - and annotatation `egi.eu/primary_group` is added to the jupyter pod. This can be used for accounting.

**Related issue :**
