### PR TITLE
feat: Filter profiles depending on the server name

### DIFF
--- a/egi_notebooks_hub/d4science.py
+++ b/egi_notebooks_hub/d4science.py
@@ -385,7 +385,11 @@ class D4ScienceSpawner(KubeSpawner):
                 override = {}
                 name = p.get("Info", {}).get("Name", "")
                 if p.get("server_option_name", "") != server_option_name:
-                    self.log.debug("Discarding %s as it uses %s", name, p.get("server_option_name", ""))
+                    self.log.debug(
+                        "Discarding %s as it uses %s",
+                        name,
+                        p.get("server_option_name", ""),
+                    )
                     continue
                 if "ImageId" in p:
                     override["image"] = p.get("ImageId", None)

--- a/egi_notebooks_hub/d4science.py
+++ b/egi_notebooks_hub/d4science.py
@@ -277,12 +277,13 @@ class D4ScienceSpawner(KubeSpawner):
     default_server_option_name = Unicode(
         "ServerOption",
         config=True,
-        help="""Name of default ServerOption (to be used if no named server is spawned)""",
+        help="""Name of default ServerOption (to be used
+                if no named server is spawned)""",
     )
     server_name_prefix = Unicode(
         "rname-",
         config=True,
-        help="""Prefix for naming the servers (avoids using capital letters)""",
+        help="""Prefix for naming the servers""",
     )
 
     def __init__(self, *args, **kwargs):

--- a/egi_notebooks_hub/services/d4science_spawn.py
+++ b/egi_notebooks_hub/services/d4science_spawn.py
@@ -1,0 +1,55 @@
+"""An helper service to redirect users to the right server option.
+
+It expects that the users is already authenticated.
+"""
+import os
+import os.path
+from urllib.parse import urlparse
+
+from tornado.httpserver import HTTPServer
+from tornado.ioloop import IOLoop
+from tornado.web import Application, RequestHandler, authenticated
+
+from jupyterhub.services.auth import HubOAuthCallbackHandler, HubOAuthenticated
+from jupyterhub.utils import url_path_join
+
+
+class D4ScienceHandler(HubOAuthenticated, RequestHandler):
+    @authenticated
+    def get(self):
+        user = self.get_current_user()
+        rname = self.request.path.split("/")[-1]
+        if rname:
+            rname = f"rname-{rname}"
+        dest_url = url_path_join("/hub/spawn/", user["name"], rname)
+        self.redirect(
+            dest_url,
+            permanent=False,
+        )
+        return
+
+
+def main():
+    app = Application(
+        [
+            (
+                url_path_join(
+                    os.environ["JUPYTERHUB_SERVICE_PREFIX"], "oauth_callback"
+                ),
+                HubOAuthCallbackHandler,
+            ),
+            (
+                r"%s/[^/]*" % os.environ["JUPYTERHUB_SERVICE_PREFIX"],
+                D4ScienceHandler,
+            ),
+        ],
+        cookie_secret=os.urandom(32),
+    )
+    http_server = HTTPServer(app)
+    url = urlparse(os.environ["JUPYTERHUB_SERVICE_URL"])
+    http_server.listen(url.port)
+    IOLoop.current().start()
+
+
+if __name__ == "__main__":
+    main()

--- a/egi_notebooks_hub/services/d4science_spawn.py
+++ b/egi_notebooks_hub/services/d4science_spawn.py
@@ -6,12 +6,11 @@ import os
 import os.path
 from urllib.parse import urlparse
 
+from jupyterhub.services.auth import HubOAuthCallbackHandler, HubOAuthenticated
+from jupyterhub.utils import url_path_join
 from tornado.httpserver import HTTPServer
 from tornado.ioloop import IOLoop
 from tornado.web import Application, RequestHandler, authenticated
-
-from jupyterhub.services.auth import HubOAuthCallbackHandler, HubOAuthenticated
-from jupyterhub.utils import url_path_join
 
 
 class D4ScienceHandler(HubOAuthenticated, RequestHandler):


### PR DESCRIPTION

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

Profiles can be filtered not just by the permission but also via the
"Name" of the "ServerOption" as delivered by D4Science. This
implementation users JupyterHub's named servers to apply the filtering.
A helper service facilitates redirecting to the right spawner page.

<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :** https://support.d4science.org/issues/24827
