### PR TITLE
Do not try to refresh non Check-in users

### DIFF
--- a/egi_notebooks_hub/egiauthenticator.py
+++ b/egi_notebooks_hub/egiauthenticator.py
@@ -124,11 +124,13 @@ class EGICheckinAuthenticator(GenericOAuthenticator):
             self.log.debug("No auth state, assuming user is not managed with Check-in")
             return True
 
-        access_token = auth_state.get('access_token', None)
-        refresh_token = auth_state.get('refresh_token', None)
+        access_token = auth_state.get("access_token", None)
+        refresh_token = auth_state.get("refresh_token", None)
 
         if not access_token:
-            self.log.debug("No access token, assuming user is not managed with Check-in")
+            self.log.debug(
+                "No access token, assuming user is not managed with Check-in"
+            )
             return True
 
         now = time.time()


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->
Users created manually won't have access tokens or refresh tokens and therefore will fail to refresh. Detect this situation so we can have some stress tests in place.

Probably should check the validity of the access token instead of this `refresh_info` that is created after successful call of this function. 


---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
