### PR TITLE
jwt

### DIFF
--- a/egi_notebooks_hub/egiauthenticator.py
+++ b/egi_notebooks_hub/egiauthenticator.py
@@ -173,7 +173,7 @@ class EGICheckinAuthenticator(GenericOAuthenticator):
     def jwt_authenticate(self, handler, data=None):
         self.log.debug("AUTHENTICATE IS BEING CALLED!")
         self.log.debug(data)
-        return None
+        return {}
 
     async def authenticate(self, handler, data=None):
         # "regular" authentication does not have any data, assume that if

--- a/egi_notebooks_hub/egiauthenticator.py
+++ b/egi_notebooks_hub/egiauthenticator.py
@@ -17,8 +17,6 @@ from traitlets import List, Unicode, default, validate
 
 
 class JWTHandler(BaseHandler):
-    async def get_refresh_token(self):
-
     async def get(self):
         auth_header = self.request.headers.get("Authorization", "")
         if auth_header:

--- a/egi_notebooks_hub/egiauthenticator.py
+++ b/egi_notebooks_hub/egiauthenticator.py
@@ -198,7 +198,8 @@ class EGICheckinAuthenticator(GenericOAuthenticator):
         refresh_token = data.get("refresh_token", None)
         if self.enable_auth_state and not refresh_token:
             self.log.debug(
-                "Refresh token was empty, will try to pull refresh_token from previous auth_state"
+                "Refresh token was empty, will try to pull refresh_token from "
+                "previous auth_state"
             )
             refresh_token = await self.get_prev_refresh_token(handler, username)
             if refresh_token:

--- a/egi_notebooks_hub/egiauthenticator.py
+++ b/egi_notebooks_hub/egiauthenticator.py
@@ -185,9 +185,10 @@ class EGICheckinAuthenticator(GenericOAuthenticator):
     )
 
     async def jwt_authenticate(self, handler, data=None):
-        self.log.debug("AUTHENTICATE IS BEING CALLED!")
-        user_info = await self.token_to_user(data)
-        self.log.debug(user_info)
+        try:
+            user_info = await self.token_to_user(data)
+        except HTTPClientError:
+            raise web.HTTPError(403)
         # this code below comes is from oauthenticator authenticate
         # we cannot directly call that method as we don't obtain the access
         # token with the code grant but they pass it to us directly

--- a/egi_notebooks_hub/services/api_wrapper.py
+++ b/egi_notebooks_hub/services/api_wrapper.py
@@ -1,34 +1,53 @@
 import httpx
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 
 app = FastAPI()
 
-AUTH_HEADER = "Authorization"
+AUTH_HEADER = "authorization"
 TOKEN_TYPE = "bearer"
 URL = "http://localhost:8000/hub/jwt_login"
 API_URL = "http://localhost:8000/hub/api"
 PREFIX = "services/jwt"
 
 
-# this could be way more generic and moved to a base function and then
-# a thin wrapper for get/put/post/etc...
+# wrapping all the HTTP actions in a single function
 @app.get("/{svc_path:path}")
+@app.put("/{svc_path:path}")
+@app.post("/{svc_path:path}")
+@app.delete("/{svc_path:path}")
+@app.options("/{svc_path:path}")
+@app.head("/{svc_path:path}")
+@app.patch("/{svc_path:path}")
+@app.trace("/{svc_path:path}")
 async def api_wrapper(request: Request, svc_path: str):
-    user_token = {}
+    token_header = {}
     if AUTH_HEADER in request.headers:
         f = request.headers[AUTH_HEADER].split()
         if len(f) == 2 and f[0].lower() == TOKEN_TYPE:
-            async with httpx.AsyncClient() as client:
-                r = await client.get(
-                    URL, headers={AUTH_HEADER: request.headers[AUTH_HEADER]}
+            try:
+                async with httpx.AsyncClient() as client:
+                    r = await client.get(
+                        URL, headers={AUTH_HEADER: request.headers[AUTH_HEADER]}
+                    )
+                    r.raise_for_status()
+                    user_token = r.json()
+                    token_header[AUTH_HEADER] = f"token {user_token['token']}"
+            except httpx.HTTPStatusError as exc:
+                raise HTTPException(
+                    status_code=exc.response.status_code, detail=exc.response.text
                 )
-                # errors should kick me out
-                user_token = r.json()
-    # assume we have the user_token here
+    content = await request.body()
     api_path = svc_path.removeprefix(PREFIX)
     async with httpx.AsyncClient() as client:
         # which headers do we need to preserve?
-        headers = {"Authorization": f"token {user_token['token']}"}
-        r = await client.get(API_URL + api_path, headers=headers)
+        headers = dict(request.headers)
+        if AUTH_HEADER in headers:
+            del headers[AUTH_HEADER]
+        headers.update(token_header)
+        method = getattr(client, request.method.lower())
+        if content:
+            r = await method(API_URL + api_path, content=content, headers=headers)
+        else:
+            r = await method(API_URL + api_path, headers=headers)
         # is this a correct assumption?
         return r.json()

--- a/egi_notebooks_hub/services/api_wrapper.py
+++ b/egi_notebooks_hub/services/api_wrapper.py
@@ -10,11 +10,6 @@ API_URL = "http://localhost:8000/hub/api"
 PREFIX = "services/jwt"
 
 
-async def request(client):
-    response = await client.get(URL)
-    return response.text
-
-
 # this could be way more generic and moved to a base function and then
 # a thin wrapper for get/put/post/etc...
 @app.get("/{svc_path:path}")

--- a/egi_notebooks_hub/services/api_wrapper.py
+++ b/egi_notebooks_hub/services/api_wrapper.py
@@ -1,0 +1,43 @@
+from typing import Union
+
+from fastapi import FastAPI, Request
+import httpx
+
+app = FastAPI()
+
+AUTH_HEADER = "Authorization"
+TOKEN_TYPE = "bearer"
+URL = "http://localhost:8000/hub/jwt_login"
+API_URL = "http://localhost:8000/hub/api"
+PREFIX = "services/jwt"
+
+
+async def request(client):
+    response = await client.get(URL)
+    return response.text
+
+
+# this could be way more generic and moved to a base function and then
+# a thin wrapper for get/put/post/etc...
+@app.get("/{svc_path:path}")
+async def api_wrapper(request: Request, svc_path: str):
+    user_token = {}
+    if AUTH_HEADER in request.headers:
+        f = request.headers[AUTH_HEADER].split()
+        if len(f) == 2 and f[0].lower() == TOKEN_TYPE:
+            async with httpx.AsyncClient() as client:
+                r = await client.get(
+                    URL, headers={AUTH_HEADER: request.headers[AUTH_HEADER]}
+                )
+                # errors should kick me out
+                user_token = r.json()
+    # assume we have the user_token here
+    api_path = svc_path.removeprefix(PREFIX)
+    print(svc_path)
+    print(api_path)
+    async with httpx.AsyncClient() as client:
+        # which headers do we need to preserve?
+        headers = {"Authorization": f"token {user_token['token']}"}
+        r = await client.get(API_URL + api_path, headers=headers)
+        # is this a correct assumption?
+        return r.json()

--- a/egi_notebooks_hub/services/api_wrapper.py
+++ b/egi_notebooks_hub/services/api_wrapper.py
@@ -1,7 +1,5 @@
-from typing import Union
-
-from fastapi import FastAPI, Request
 import httpx
+from fastapi import FastAPI, Request
 
 app = FastAPI()
 
@@ -33,8 +31,6 @@ async def api_wrapper(request: Request, svc_path: str):
                 user_token = r.json()
     # assume we have the user_token here
     api_path = svc_path.removeprefix(PREFIX)
-    print(svc_path)
-    print(api_path)
     async with httpx.AsyncClient() as client:
         # which headers do we need to preserve?
         headers = {"Authorization": f"token {user_token['token']}"}

--- a/egi_notebooks_hub/services/d4science_spawn.py
+++ b/egi_notebooks_hub/services/d4science_spawn.py
@@ -2,6 +2,7 @@
 
 It expects that the users is already authenticated.
 """
+
 import os
 import os.path
 from urllib.parse import urlparse

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ jupyterhub>=4.0.2
 oauthenticator>=16.1.0
 jupyterhub-kubespawner>=6.1.0
 xmltodict
+fastapi


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

JWT authentication and an API wrapper capable of from a JWT token call the hub API with a valid internal hub token and return results.

The JWT authentication extends the `egiauthenticator` with a new handler listening at `/jwt_login` that when sent a valid JWT token it will authenticate the user as with the regular code grant based authentication and return a JSON like this:

```
{
  "token": "<a valid hub api token with same duration as the JWT>",
  "user": "<the hub user name>"
}
```

This could be used by an API client directly to perform any subsequent calls.

In the EOSC procurement node we add an additional wrapper so the client is not aware of the internal hub token. This wrapper will forward any call to the hub API and will attempt to authenticate with a JWT and use the returned token for the API call. The wrapper is a simple fastAPI application that can be run as a service of the Hub:

```
c.JupyterHub.services = [
    {
        "name": "jwt",
        "url": "http://localhost:1984/",
        "display": False,
        "command": ["fastapi", "run", "--port", "1984", "/egi-notebooks-hub/egi_notebooks_hub/services/api_wrapper.py"]
    }
]
```

What's missing:
- avoid hardcoding configuration (paths, ports, ...)
- maybe caching of tokens
- dealing with refresh tokens


<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
