### PR TITLE
EOSC Node AAI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,3 +30,6 @@ jobs:
           DISABLE_ERRORS: false
           # JSCPD is failing in the symlink, so avoiding it
           VALIDATE_JSCPD: false
+          # Pylint is too picky about everything, not ready
+          # for this yet here
+          VALIDATE_PYTHON_PYLINT: false

--- a/egi_notebooks_hub/d4science.py
+++ b/egi_notebooks_hub/d4science.py
@@ -188,11 +188,12 @@ class D4ScienceOauthenticator(GenericOAuthenticator):
     async def authenticate(self, handler, data=None):
         # first get authorized upstream
         user_data = await super().authenticate(handler, data)
-        context = quote_plus(getattr(self, "d4science_context", None))
+        context = getattr(self, "d4science_context", None)
         self.log.debug("Context is %s", context)
         if not context:
             self.log.error("Unable to get the user context")
             raise web.HTTPError(403)
+        context = quote_plus(context)
         access_token = user_data["auth_state"]["access_token"]
         extra_params = {
             "claim_token": base64.b64encode(

--- a/egi_notebooks_hub/egiauthenticator.py
+++ b/egi_notebooks_hub/egiauthenticator.py
@@ -297,6 +297,7 @@ class EGICheckinAuthenticator(GenericOAuthenticator):
 
 class EOSCNodeAuthenticator(EGICheckinAuthenticator):
     """Adaptation of the EGI Check-in Authenticator to the EOSC EU Node authorization needs"""
+
     personal_project_re = Unicode(
         r"^urn:geant:eosc-federation.eu:group:pp:Personal%20Project%20Name-(.*)$",
         config=True,

--- a/egi_notebooks_hub/egiauthenticator.py
+++ b/egi_notebooks_hub/egiauthenticator.py
@@ -185,7 +185,6 @@ class EGICheckinAuthenticator(GenericOAuthenticator):
         return await self.update_auth_model(auth_model)
 
     def get_primary_group(self, oauth_user):
-        # this has changed from one authenticator version to another
         groups = self.get_user_groups(oauth_user)
         # first group as the primary, priority is governed by ordering in
         # Authenticator.allowed_groups

--- a/egi_notebooks_hub/egiauthenticator.py
+++ b/egi_notebooks_hub/egiauthenticator.py
@@ -150,6 +150,8 @@ class EGICheckinAuthenticator(GenericOAuthenticator):
         too long.
         """,
     )
+    # reasonable defaults for Check-in
+    manage_groups = True
 
     async def jwt_authenticate(self, handler, data=None):
         try:
@@ -182,12 +184,12 @@ class EGICheckinAuthenticator(GenericOAuthenticator):
         # check_allowed, such as admin status and group memberships
         return await self.update_auth_model(auth_model)
 
-    def get_primary_group(self, auth_state):
-        groups = self.get_user_groups(auth_state)
+    def get_primary_group(self, oauth_user):
+        # this has changed from one authenticator version to another
+        groups = self.get_user_groups(oauth_user)
         # first group as the primary, priority is governed by ordering in
         # Authenticator.allowed_groups
         first_group = next((v for v in self.allowed_groups if v in groups), None)
-        self.log.info("Primary group: %s", first_group)
         return first_group
 
     async def authenticate(self, handler, data=None):
@@ -201,12 +203,13 @@ class EGICheckinAuthenticator(GenericOAuthenticator):
         if user_info is None or self.claim_groups_key is None:
             return user_info
         auth_state = user_info.get("auth_state", {})
-        oauth_user = auth_state.get("oauth_user", {})
+        oauth_user = auth_state.get(self.user_auth_state_key, {})
         if not oauth_user:
             self.log.warning("Missing OAuth info")
             return user_info
 
-        first_group = self.get_primary_group(auth_state)
+        first_group = self.get_primary_group(oauth_user)
+        self.log.info("Primary group: %s", first_group)
         if first_group:
             auth_state["primary_group"] = first_group
 
@@ -294,26 +297,22 @@ class EGICheckinAuthenticator(GenericOAuthenticator):
 
 class EOSCNodeAuthenticator(EGICheckinAuthenticator):
     """Adaptation of the EGI Check-in Authenticator to the EOSC EU Node authorization needs"""
-
-    personal_project = Unicode(
-        "^urn:geant:eosc-federation.eu:group:pp:Personal%20Project%20Name-\(.*\)$",
+    personal_project_re = Unicode(
+        r"^urn:geant:eosc-federation.eu:group:pp:Personal%20Project%20Name-(.*)$",
         config=True,
-        help="""Regular expression to match the personal groups""",
+        help="""Regular expression to match the personal groups.
+                If the regular expression contains a group and matches, it will be used as
+                the name of the Personal project group""",
     )
 
-    def get_primary_group(self, auth_state):
-        groups = self.get_user_groups(auth_state)
+    def get_primary_group(self, oauth_user):
         # first group is the personal project, which is different for every user
         # if not available call super()
-        first_group = next(
-            (
-                g
-                for g in self.get_user_groups(auth_state)
-                if re.match(self.personal_project, g)
-            ),
-            None,
-        )
-        if first_group:
-            return first_group
-        else:
-            return super().get_primary_group(auth_state)
+        for g in self.get_user_groups(oauth_user):
+            m = re.match(self.personal_project_re, g)
+            if m:
+                if m.groups():
+                    return m.groups()[0]
+                else:
+                    return g
+        return super().get_primary_group(oauth_user)

--- a/egi_notebooks_hub/egiauthenticator.py
+++ b/egi_notebooks_hub/egiauthenticator.py
@@ -297,6 +297,7 @@ class EGICheckinAuthenticator(GenericOAuthenticator):
 class EOSCNodeAuthenticator(EGICheckinAuthenticator):
     """Adaptation of the EGI Check-in Authenticator to the
     EOSC EU Node authorization needs"""
+    login_service = "EOSC AAI"
 
     personal_project_re = Unicode(
         r"^urn:geant:eosc-federation.eu:group:pp:Personal%20Project%20Name-(.*)$",

--- a/egi_notebooks_hub/egiauthenticator.py
+++ b/egi_notebooks_hub/egiauthenticator.py
@@ -296,14 +296,15 @@ class EGICheckinAuthenticator(GenericOAuthenticator):
 
 
 class EOSCNodeAuthenticator(EGICheckinAuthenticator):
-    """Adaptation of the EGI Check-in Authenticator to the EOSC EU Node authorization needs"""
+    """Adaptation of the EGI Check-in Authenticator to the
+       EOSC EU Node authorization needs"""
 
     personal_project_re = Unicode(
         r"^urn:geant:eosc-federation.eu:group:pp:Personal%20Project%20Name-(.*)$",
         config=True,
         help="""Regular expression to match the personal groups.
-                If the regular expression contains a group and matches, it will be used as
-                the name of the Personal project group""",
+                If the regular expression contains a group and matches, it will be
+                used as the name of the Personal project group""",
     )
 
     def get_primary_group(self, oauth_user):

--- a/egi_notebooks_hub/egiauthenticator.py
+++ b/egi_notebooks_hub/egiauthenticator.py
@@ -297,7 +297,7 @@ class EGICheckinAuthenticator(GenericOAuthenticator):
 
 class EOSCNodeAuthenticator(EGICheckinAuthenticator):
     """Adaptation of the EGI Check-in Authenticator to the
-       EOSC EU Node authorization needs"""
+    EOSC EU Node authorization needs"""
 
     personal_project_re = Unicode(
         r"^urn:geant:eosc-federation.eu:group:pp:Personal%20Project%20Name-(.*)$",

--- a/egi_notebooks_hub/egiauthenticator.py
+++ b/egi_notebooks_hub/egiauthenticator.py
@@ -297,6 +297,7 @@ class EGICheckinAuthenticator(GenericOAuthenticator):
 class EOSCNodeAuthenticator(EGICheckinAuthenticator):
     """Adaptation of the EGI Check-in Authenticator to the
     EOSC EU Node authorization needs"""
+
     login_service = "EOSC AAI"
 
     personal_project_re = Unicode(

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ tag_svn_revision = 0
 [entry_points]
 jupyterhub.authenticators =
     egiauthenticator = egi_notebooks_hub.egiauthenticator:EGICheckinAuthenticator
+    eoscauthenticator = egi_notebooks_hub.egiauthenticator:EOSCNodeAuthenticator
     d4scienceauthenticator = egi_notebooks_hub.d4science:D4ScienceOauthenticator
     onedataauthenticator = egi_notebooks_hub.onedata:OnedataAuthenticator
 jupyterhub.spawners =


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

Implement the support for the personal projects as the primary group of the user so this can be properly reported in accounting.

Creates a new `EOSCNodeAuthenticator` that will try to get the primary group of the user from the entitlements by matching a `personal_project_re` regular expression with default value:
```
r"^urn:geant:eosc-federation.eu:group:pp:Personal%20Project%20Name-(.*)$"
```
If the RE contains a group, the match will be used as the name for the primary group of the user. If it does not match, the primary group will be the first group of the user that matches the `allowed_groups`.

Sample configuration
```
c.JupyterHub.authenticator_class = "eoscauthenticator"
c.EOSCNodeAuthenticator.allow_all = True
c.EOSCNodeAuthenticator.claim_groups_key = "eduperson_entitlement"
c.EOSCNodeAuthenticator.personal_project = r"^urn:mace:egi.eu:group:fedcloud-([^#]*)#.*$"
```

This will match `urn:mace:egi.eu:group:fedcloud-users#sso.egi.eu` and return `users` as primary group

Without groups in the re:
```
c.JupyterHub.authenticator_class = "eoscauthenticator"
c.EOSCNodeAuthenticator.allow_all = True
c.EOSCNodeAuthenticator.claim_groups_key = "eduperson_entitlement"
c.EOSCNodeAuthenticator.personal_project = r"^urn:mace:egi.eu:group:fedcloud-.*$"
```
This will match `urn:mace:egi.eu:group:fedcloud-users#sso.egi.eu` and return `urn:mace:egi.eu:group:fedcloud-users#sso.egi.eu` as primary group


---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
