### PR TITLE
Enforce refresh token clean-up

### DIFF
--- a/egi_notebooks_hub/egiauthenticator.py
+++ b/egi_notebooks_hub/egiauthenticator.py
@@ -21,6 +21,7 @@ from traitlets import List, Unicode, default, validate
 
 class JWTHandler(BaseHandler):
     """Handler for authentication with JWT tokens"""
+
     async def exchange_for_refresh_token(self, access_token):
         self.log.debug("Exchanging access token for refresh")
         http_client = AsyncHTTPClient()

--- a/egi_notebooks_hub/egiauthenticator.py
+++ b/egi_notebooks_hub/egiauthenticator.py
@@ -20,6 +20,7 @@ from traitlets import List, Unicode, default, validate
 
 
 class JWTHandler(BaseHandler):
+    """Handler for authentication with JWT tokens"""
     async def exchange_for_refresh_token(self, access_token):
         self.log.debug("Exchanging access token for refresh")
         http_client = AsyncHTTPClient()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ jupyterhub>=4.0.2
 oauthenticator>=16.3.0
 jupyterhub-kubespawner>=6.1.0
 xmltodict
-fastapi
+fastapi[standard]
 pydantic-settings
 pbr

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jupyterhub>=4.0.2
-oauthenticator>=16.3.0
+oauthenticator>=16.3.0,<17
 jupyterhub-kubespawner>=6.1.0
 xmltodict
 fastapi[standard]


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

Remove the stale user info whenever the refresh process fails so the user is forced to authenticate again from scratch. This will force obtaining a new refresh token, before the broken token would remain unchanged when loggin in via JWT.

Also check the validity of the access token so the refresh does not need to happen if the user has a valid token in place.

<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
