### PR TITLE
Create usernames on the fly for service accounts

### DIFF
--- a/egi_notebooks_hub/egiauthenticator.py
+++ b/egi_notebooks_hub/egiauthenticator.py
@@ -338,7 +338,12 @@ class EGICheckinAuthenticator(GenericOAuthenticator):
         try:
             if jwt.decode(
                 access_token,
-                options=dict(verify_signature=False, verify_exp=True),
+                options=dict(
+                    verify_signature=False,
+                    verify_exp=True,
+                    # we want to fall on the safe side for refreshing
+                    leeway=self.auth_refresh_age + 1,
+                ),
             ):
                 # access token is good, no need to keep going
                 self.log.debug("Access token is still good, no refresh needed")

--- a/egi_notebooks_hub/egiauthenticator.py
+++ b/egi_notebooks_hub/egiauthenticator.py
@@ -252,7 +252,8 @@ class EGICheckinAuthenticator(GenericOAuthenticator):
         if not username:
             if not self.allow_anonymous:
                 message = (
-                    f"No {self.username_claim} found in {user_info} and anonymous users not enabled",
+                    f"No {self.username_claim} found in {user_info}"
+                    "and anonymous users not enabled"
                 )
                 self.log.error(message)
                 raise ValueError(message)

--- a/egi_notebooks_hub/egiauthenticator.py
+++ b/egi_notebooks_hub/egiauthenticator.py
@@ -133,7 +133,8 @@ class JWTHandler(BaseHandler):
                 # roles=token_roles,
                 # scopes=token_scopes,
             )
-            auth_state["jwt_api_token"] = api_token
+            if auth_state:
+                auth_state["jwt_api_token"] = api_token
             await user.save_auth_state(auth_state)
         self.finish({"token": api_token, "user": user.name})
 
@@ -232,7 +233,7 @@ class EGICheckinAuthenticator(GenericOAuthenticator):
                 claim and create usernames for them on the fly""",
     )
     anonymous_username_prefix = Unicode(
-        "anon-",
+        "anon",
         config=True,
         help="""A prefix for the the anonymous users""",
     )

--- a/egi_notebooks_hub/egiauthenticator.py
+++ b/egi_notebooks_hub/egiauthenticator.py
@@ -8,6 +8,7 @@ import os
 import re
 import time
 from urllib.parse import urlencode
+import uuid
 
 import jwt
 import jwt.exceptions
@@ -227,6 +228,15 @@ class EGICheckinAuthenticator(GenericOAuthenticator):
     @default("manage_groups")
     def _manage_groups_default(self):
         return True
+
+    def user_info_to_username(self, user_info):
+        try:
+            return super().user_info_to_username(user_info)
+        except ValueError as e:
+            # let's treat this as an anonymous user with a unique name
+            # This won't help in caching the tokens though, as there
+            # is no way to understand whether the user is the same or not
+            return str(uuid.uuid4())
 
     async def jwt_authenticate(self, handler, data=None):
         try:

--- a/egi_notebooks_hub/egiauthenticator.py
+++ b/egi_notebooks_hub/egiauthenticator.py
@@ -7,8 +7,8 @@ import json
 import os
 import re
 import time
-from urllib.parse import urlencode
 import uuid
+from urllib.parse import urlencode
 
 import jwt
 import jwt.exceptions
@@ -232,7 +232,7 @@ class EGICheckinAuthenticator(GenericOAuthenticator):
     def user_info_to_username(self, user_info):
         try:
             return super().user_info_to_username(user_info)
-        except ValueError as e:
+        except ValueError:
             # let's treat this as an anonymous user with a unique name
             # This won't help in caching the tokens though, as there
             # is no way to understand whether the user is the same or not

--- a/egi_notebooks_hub/egiauthenticator.py
+++ b/egi_notebooks_hub/egiauthenticator.py
@@ -251,9 +251,10 @@ class EGICheckinAuthenticator(GenericOAuthenticator):
                 raise e
             # let's treat this as an anonymous user with a name
             # that's generated as a hash of user_info
+            info_str = json.dumps(user_info, sort_keys=True).encode("utf-8")
             return "{0}-{1}".format(
                 self.anonymous_username_prefix,
-                hashlib.sha256(json.dumps(user_info, sort_keys=True)).hexdigest(),
+                hashlib.sha256(info_str).hexdigest(),
             )
 
     async def jwt_authenticate(self, handler, data=None):


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

Assume the user can somehow be authorized afterwards. Potentially we could look for an alternative attribute instead of `sub` as fallback.


<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
