### PR TITLE
Use introspection

### DIFF
--- a/egi_notebooks_hub/egiauthenticator.py
+++ b/egi_notebooks_hub/egiauthenticator.py
@@ -109,13 +109,9 @@ class JWTHandler(BaseHandler):
                 "token_type": "bearer",
             }
             user = await self.login_user(token_info)
-            print("&" * 80)
-            print(user)
             if user is None:
                 raise web.HTTPError(403, self.authenticator.custom_403_message)
             auth_state = await user.get_auth_state()
-            print("*" * 80)
-            print(auth_state)
             if auth_state and not auth_state.get("refresh_token", None):
                 self.log.debug("Refresh token is not available")
                 refresh_token = await self.exchange_for_refresh_token(jwt_token)

--- a/egi_notebooks_hub/egiauthenticator.py
+++ b/egi_notebooks_hub/egiauthenticator.py
@@ -185,6 +185,7 @@ class EGICheckinAuthenticator(GenericOAuthenticator):
         <https://datatracker.ietf.org/doc/html/rfc7662>`_.
         """,
     )
+
     @default("introspect_url")
     def _introspect_url_default(self):
         return (
@@ -293,7 +294,7 @@ class EGICheckinAuthenticator(GenericOAuthenticator):
 
     async def introspect_token(self, data):
         if "access_token" not in data:
-            raise web.HTTPError(500, f"No access token available")
+            raise web.HTTPError(500, "No access token available")
 
         # Taken from build_token_info_request_headers of oauthenticator
         headers = {

--- a/egi_notebooks_hub/egiauthenticator.py
+++ b/egi_notebooks_hub/egiauthenticator.py
@@ -3,6 +3,7 @@
 Uses OpenID Connect with aai.egi.eu
 """
 
+import base64
 import hashlib
 import json
 import os
@@ -108,9 +109,13 @@ class JWTHandler(BaseHandler):
                 "token_type": "bearer",
             }
             user = await self.login_user(token_info)
+            print("&" * 80)
+            print(user)
             if user is None:
                 raise web.HTTPError(403, self.authenticator.custom_403_message)
             auth_state = await user.get_auth_state()
+            print("*" * 80)
+            print(auth_state)
             if auth_state and not auth_state.get("refresh_token", None):
                 self.log.debug("Refresh token is not available")
                 refresh_token = await self.exchange_for_refresh_token(jwt_token)
@@ -171,6 +176,23 @@ class EGICheckinAuthenticator(GenericOAuthenticator):
     def _userdata_url_default(self):
         return (
             "https://%s/auth/realms/egi/protocol/openid-connect/userinfo"
+            % self.checkin_host
+        )
+
+    introspect_url = Unicode(
+        config=True,
+        help="""
+        The URL to where this authenticator makes a request to
+        introspect user tokens received via the jwt authentication
+
+        For more context, see `RFC7622
+        <https://datatracker.ietf.org/doc/html/rfc7662>`_.
+        """,
+    )
+    @default("introspect_url")
+    def _introspect_url_default(self):
+        return (
+            "https://%s/auth/realms/egi/protocol/openid-connect/token/introspect"
             % self.checkin_host
         )
 
@@ -273,9 +295,33 @@ class EGICheckinAuthenticator(GenericOAuthenticator):
             )
         return username
 
+    async def introspect_token(self, data):
+        if "access_token" not in data:
+            raise web.HTTPError(500, f"No access token available")
+
+        # Taken from build_token_info_request_headers of oauthenticator
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
+            "User-Agent": "JupyterHub",
+        }
+        b64key = base64.b64encode(
+            bytes(f"{self.client_id}:{self.client_secret}", "utf8")
+        )
+        headers.update({"Authorization": f'Basic {b64key.decode("utf8")}'})
+        params = {"token": data["access_token"]}
+        return await self.httpfetch(
+            self.introspect_url,
+            label="Introspecting token...",
+            method="POST",
+            headers=headers,
+            body=urlencode(params).encode("utf-8"),
+            validate_cert=self.validate_server_cert,
+        )
+
     async def jwt_authenticate(self, handler, data=None):
         try:
-            user_info = await self.token_to_user(data)
+            user_info = await self.introspect_token(data)
         except HTTPClientError:
             raise web.HTTPError(403)
         # this code below comes is from oauthenticator authenticate


### PR DESCRIPTION

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->
Use the introspection endpoint instead of the userinfo when coming through jwt authentication route. This allows for getting information for service accounts that are delivering an empty userinfo.

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
