### PR TITLE
fix: Moving load_user_options into pre_spawn_hook

### DIFF
--- a/egi_notebooks_hub/egispawner.py
+++ b/egi_notebooks_hub/egispawner.py
@@ -188,15 +188,6 @@ class EGISpawner(KubeSpawner):
             vols.append(v)
         self.volumes = vols
 
-    async def load_user_options(self):
-        """
-        Tunes the configuration of the volumes before the start
-        and once the overrides have been loaded.
-        """
-        await super().load_user_options()
-        await self.configure_user_volumes()
-        await self.configure_secret_volumes()
-
     def _profile_filter(self, spawner):
         profile_list = []
         if spawner._profile_config:
@@ -210,6 +201,7 @@ class EGISpawner(KubeSpawner):
     async def pre_spawn_hook(self, spawner):
         """
         Do actions before spawning.
-        This is for now empty to ensure compability with the existing child spawners
         """
-        pass
+        await super().load_user_options()
+        await self.configure_user_volumes()
+        await self.configure_secret_volumes()


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

Moving load_user_options into pre_spawn_hook due to some methods not being executed in required order if they are in
load_user_options. 

E.g. monitor user won't be able to spawn server as it fails to create secret if the flow is present in load_user_options.

<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

