### PR TITLE
Add Phase 6 running JupyterHub integration and spawner lifecycle tests

### DIFF
--- a/.github/workflows/hub-tests.yml
+++ b/.github/workflows/hub-tests.yml
@@ -1,0 +1,91 @@
+---
+name: EGI Hub Running Hub Tests
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+
+jobs:
+  hub-tests:
+    runs-on: ubuntu-latest
+
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "latest"
+
+      - name: Install configurable-http-proxy
+        run: npm install -g configurable-http-proxy
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+          cache: "pip"
+
+      - name: Start local k3s cluster
+        uses: jupyterhub/action-k3s-helm@v4
+        with:
+          k3s-channel: latest
+
+      - name: Wait for cluster
+        run: |
+          kubectl get nodes
+          kubectl wait --for=condition=Ready nodes --all --timeout=120s
+
+      - name: Show cluster info
+        run: |
+          kubectl version
+          kubectl get nodes -o wide
+          kubectl get pods -A
+          kubectl get storageclass
+
+      - name: Check Kubernetes permissions
+        run: |
+          kubectl auth can-i create namespaces
+          kubectl auth can-i delete namespaces
+          kubectl auth can-i create secrets --all-namespaces
+          kubectl auth can-i get secrets --all-namespaces
+          kubectl auth can-i update secrets --all-namespaces
+          kubectl auth can-i create persistentvolumeclaims --all-namespaces
+          kubectl auth can-i list persistentvolumeclaims --all-namespaces
+          kubectl auth can-i create pods --all-namespaces
+          kubectl auth can-i get pods --all-namespaces
+          kubectl auth can-i get pods/log --all-namespaces
+
+      - name: Create virtual environment
+        run: python -m venv .venv
+
+      - name: Install dependencies
+        run: |
+          source .venv/bin/activate
+          pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-test.txt
+          pip install -e .
+
+      - name: Run Phase 6 running Hub tests
+        run: |
+          source .venv/bin/activate
+          python -m pytest tests/phase6 -s
+
+      - name: Show remaining Phase 6 namespaces
+        if: always()
+        run: |
+          kubectl get ns | grep -E 'phase6|hub-test|egi-hub' || true
+
+      - name: Show remaining Phase 6 Pods
+        if: always()
+        run: |
+          kubectl get pods -A | grep -E 'phase6|hub-test|egi-hub|jupyterhub' || true

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-asyncio
 kubernetes-asyncio
+httpx

--- a/tests/README.md
+++ b/tests/README.md
@@ -239,3 +239,34 @@ Secret creation and update, PVC discovery, generated Secret/PVC volume
 configuration, `auth_state_hook`, `pre_spawn_hook`, Pod smoke tests, Secret and
 PVC mounts inside containers, environment variable injection, metadata
 round-trips, missing Secret/PVC failure behavior, and multi-user isolation.
+
+## Phase 6: running JupyterHub tests
+
+Files:
+
+- `phase6/jupyterhub_config.py`
+- `phase6/conftest.py`
+- `phase6/test_hub_smoke.py`
+- `phase6/test_hub_users.py`
+- `phase6/test_hub_services.py`
+- `phase6/test_hub_spawner.py`
+- `phase6/test_hub_spawner_extended.py`
+
+Phase 6 starts a real JupyterHub process with a dedicated test configuration and
+runs tests against the live Hub through HTTP/API calls. The goal is to verify the
+parts of the EGI Hub integration that only exist when JupyterHub is actually
+running: Hub API access, service registration, managed service routing, user and
+group API behavior, authorization checks, proxy routing, and Hub runtime
+stability.
+
+The same Hub configuration also uses a lightweight `EGISpawner` subclass for
+spawner lifecycle tests. This subclass still inherits from the real
+`EGISpawner`, so JupyterHub initializes the EGI spawner in a real Hub context.
+Only the actual single-user backend is replaced with a small local HTTP server,
+which makes the tests fast and stable while still verifying that Hub spawn and
+stop requests reach the spawner lifecycle.
+
+The spawner tests cover default servers, named servers, repeated start/stop
+operations, event metadata, generated EGI spawner attributes, multi-user
+isolation, cleanup behavior, route behavior after stop, and protection against
+unauthorized or invalid API calls.

--- a/tests/phase6/conftest.py
+++ b/tests/phase6/conftest.py
@@ -1,0 +1,179 @@
+"""
+Shared fixtures and helpers for Phase 6 running-Hub tests.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+PHASE6_TOKEN = "phase6-test-admin-token"
+HUB_PORT = 18000
+TOKEN_ACQUIRER_PORT = 18010
+HUB_URL = f"http://127.0.0.1:{HUB_PORT}"
+SERVICE_URL = f"{HUB_URL}/services/token-acquirer/"
+
+
+def repo_root() -> Path:
+    """Return the repository root from the Phase 6 tests directory."""
+    return Path(__file__).resolve().parents[2]
+
+
+def auth_headers() -> dict[str, str]:
+    """Return the Hub API Authorization header for the test service token."""
+    return {"Authorization": f"token {PHASE6_TOKEN}"}
+
+
+def read_log(log_path: Path) -> str:
+    """Read the JupyterHub log file captured by the running_hub fixture."""
+    try:
+        return log_path.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return ""
+
+
+def wait_for_hub_api(log_path: Path, timeout: int = 90) -> None:
+    """Wait until the running Hub API responds to the service token."""
+    deadline = time.monotonic() + timeout
+    last_error = ""
+
+    while time.monotonic() < deadline:
+        try:
+            response = httpx.get(
+                f"{HUB_URL}/hub/api",
+                headers=auth_headers(),
+                timeout=2,
+            )
+            if response.status_code == 200:
+                return
+            last_error = f"HTTP {response.status_code}: {response.text[:300]}"
+        except httpx.HTTPError as exc:
+            last_error = repr(exc)
+        time.sleep(1)
+
+    log_tail = read_log(log_path)[-5000:]
+    raise AssertionError(
+        "JupyterHub did not become ready. "
+        f"Last error: {last_error}\n\nHub log tail:\n{log_tail}"
+    )
+
+
+@pytest.fixture(scope="session")
+def running_hub() -> Iterator[dict[str, Any]]:
+    """Start a JupyterHub process and stop it after the test session."""
+    if shutil.which("configurable-http-proxy") is None:
+        pytest.skip("configurable-http-proxy is required for running Hub tests")
+
+    root = repo_root()
+    config_file = Path(__file__).with_name("jupyterhub_config.py")
+
+    with tempfile.TemporaryDirectory(prefix="egi-hub-phase6-") as tmp:
+        runtime_dir = Path(tmp)
+        log_path = runtime_dir / "jupyterhub.log"
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "PYTHONPATH": str(root),
+                "JUPYTERHUB_TEST_RUNTIME_DIR": str(runtime_dir),
+                "JUPYTERHUB_TEST_HUB_PORT": str(HUB_PORT),
+                "JUPYTERHUB_TEST_TOKEN_ACQUIRER_PORT": str(TOKEN_ACQUIRER_PORT),
+                "CONFIGPROXY_AUTH_TOKEN": "phase6-config-proxy-token",
+            }
+        )
+
+        with log_path.open("w", encoding="utf-8") as log_file:
+            process = subprocess.Popen(
+                [sys.executable, "-m", "jupyterhub", "-f", str(config_file)],
+                cwd=root,
+                env=env,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+
+        try:
+            wait_for_hub_api(log_path)
+            yield {"process": process, "log_path": log_path}
+        finally:
+            process.terminate()
+            try:
+                process.wait(timeout=20)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=20)
+
+
+@pytest.fixture
+def unique_name() -> str:
+    """Return a short unique name suitable for Hub users and groups."""
+    return f"phase6-{uuid.uuid4().hex[:10]}"
+
+
+def api_get(path: str, *, token: bool = True) -> httpx.Response:
+    """Run a GET request against the Hub API."""
+    headers = auth_headers() if token else None
+    return httpx.get(f"{HUB_URL}{path}", headers=headers, timeout=5)
+
+
+def api_post(
+    path: str,
+    *,
+    json: dict[str, Any] | None = None,
+    token: bool = True,
+) -> httpx.Response:
+    """Run a POST request against the Hub API."""
+    headers = auth_headers() if token else None
+    return httpx.post(f"{HUB_URL}{path}", headers=headers, json=json, timeout=5)
+
+
+def api_delete(path: str, *, token: bool = True) -> httpx.Response:
+    """Run a DELETE request against the Hub API."""
+    headers = auth_headers() if token else None
+    return httpx.delete(f"{HUB_URL}{path}", headers=headers, timeout=5)
+
+
+def create_user(name: str) -> httpx.Response:
+    """Create a Hub user and accept created or already-existing states."""
+    response = api_post(f"/hub/api/users/{name}")
+    assert response.status_code in {201, 409}
+    return response
+
+
+def delete_user(name: str) -> httpx.Response:
+    """Delete a Hub user and accept deleted or already-missing states."""
+    response = api_delete(f"/hub/api/users/{name}")
+    assert response.status_code in {204, 404}
+    return response
+
+
+def create_group(name: str) -> httpx.Response:
+    """Create a Hub group and accept created or already-existing states."""
+    response = api_post(f"/hub/api/groups/{name}")
+    assert response.status_code in {201, 409}
+    return response
+
+
+def delete_group(name: str) -> httpx.Response:
+    """Delete a Hub group and accept deleted or already-missing states."""
+    response = api_delete(f"/hub/api/groups/{name}")
+    assert response.status_code in {204, 404}
+    return response
+
+
+def service_names(payload: Any) -> set[str]:
+    """Extract service names from Hub API service-list payloads."""
+    if isinstance(payload, dict):
+        values = payload.values()
+    else:
+        values = payload
+    return {item["name"] for item in values}

--- a/tests/phase6/jupyterhub_config.py
+++ b/tests/phase6/jupyterhub_config.py
@@ -1,0 +1,167 @@
+"""
+Unified JupyterHub configuration used by Phase 6 running-Hub tests.
+
+The same config supports:
+- Hub API and service tests
+- Hub user/group tests
+- Hub spawner lifecycle tests
+"""
+
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from jupyterhub.auth import DummyAuthenticator
+
+from egi_notebooks_hub.egispawner import EGISpawner
+
+try:
+    c: Any = get_config()  # type: ignore[name-defined]  # noqa: F821
+except NameError:
+    from traitlets.config import Config
+
+    c = Config()
+
+runtime_dir = Path(os.environ["JUPYTERHUB_TEST_RUNTIME_DIR"])
+runtime_dir.mkdir(parents=True, exist_ok=True)
+
+hub_port = int(os.environ.get("JUPYTERHUB_TEST_HUB_PORT", "18000"))
+token_acquirer_port = int(
+    os.environ.get("JUPYTERHUB_TEST_TOKEN_ACQUIRER_PORT", "18010")
+)
+spawner_events_file = runtime_dir / "spawner-events.jsonl"
+
+
+class Phase6RecordingEGISpawner(EGISpawner):
+    """EGISpawner subclass used by running-Hub lifecycle tests."""
+
+    def _record_event(self, event, **extra):
+        payload = {
+            "event": event,
+            "user": self.user.name,
+            "spawner_class": type(self).__name__,
+            "namespace": getattr(self, "namespace", None),
+            "token_secret_name": getattr(self, "token_secret_name", None),
+            "token_secret_volume_name": getattr(
+                self,
+                "_token_secret_volume_name",
+                None,
+            ),
+            "token_mount_path": getattr(self, "token_mount_path", None),
+            "mount_secrets_volume": getattr(self, "mount_secrets_volume", None),
+            "pvc_name": getattr(self, "pvc_name", None),
+            "timestamp": time.time(),
+        }
+        payload.update(extra)
+        with spawner_events_file.open("a", encoding="utf-8") as events:
+            events.write(json.dumps(payload, sort_keys=True) + "\n")
+
+    @staticmethod
+    def _free_port():
+        sock = socket.socket()
+        sock.bind(("127.0.0.1", 0))
+        _, port = sock.getsockname()
+        sock.close()
+        return port
+
+    async def start(self):
+        server_dir = runtime_dir / f"server-{self.user.name}-{self.name or 'default'}"
+        server_dir.mkdir(parents=True, exist_ok=True)
+        (server_dir / "index.html").write_text(
+            f"phase6 user server for {self.user.name}\n",
+            encoding="utf-8",
+        )
+
+        port = self._free_port()
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "http.server",
+                str(port),
+                "--bind",
+                "127.0.0.1",
+                "--directory",
+                str(server_dir),
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        self.phase6_process = process
+        self.phase6_port = port
+        self._record_event(
+            "start",
+            port=port,
+            pid=process.pid,
+            server_name=self.name,
+        )
+
+        return "127.0.0.1", port
+
+    async def stop(self, now=False):
+        process = getattr(self, "phase6_process", None)
+        if process is not None and process.poll() is None:
+            if now:
+                process.kill()
+            else:
+                process.terminate()
+            try:
+                process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                os.killpg(process.pid, signal.SIGKILL)
+                process.wait(timeout=10)
+
+        self._record_event("stop", now=now, server_name=self.name)
+
+    async def poll(self):
+        process = getattr(self, "phase6_process", None)
+        if process is None:
+            return 0
+        return process.poll()
+
+
+c.JupyterHub.bind_url = f"http://127.0.0.1:{hub_port}"
+c.JupyterHub.hub_ip = "127.0.0.1"
+c.JupyterHub.hub_connect_ip = "127.0.0.1"
+c.JupyterHub.db_url = f"sqlite:///{runtime_dir / 'jupyterhub.sqlite'}"
+c.JupyterHub.cookie_secret_file = str(runtime_dir / "jupyterhub_cookie_secret")
+c.JupyterHub.pid_file = str(runtime_dir / "jupyterhub.pid")
+c.JupyterHub.log_level = "DEBUG"
+c.JupyterHub.allow_named_servers = True
+
+c.JupyterHub.authenticator_class = DummyAuthenticator
+c.Authenticator.admin_users = {"alice"}
+c.Authenticator.allowed_users = {"alice"}
+
+c.JupyterHub.spawner_class = Phase6RecordingEGISpawner
+c.KubeSpawner.namespace = os.environ.get("JUPYTERHUB_TEST_K8S_NAMESPACE", "default")
+
+c.JupyterHub.services = [
+    {
+        "name": "test-admin",
+        "api_token": "phase6-test-admin-token",
+    },
+    {
+        "name": "token-acquirer",
+        "url": f"http://127.0.0.1:{token_acquirer_port}",
+        "command": [
+            sys.executable,
+            "-c",
+            "from egi_notebooks_hub.services.token_acquirer import main; main()",
+        ],
+    },
+]
+
+c.JupyterHub.load_roles = [
+    {
+        "name": "admin",
+        "services": ["test-admin"],
+    }
+]

--- a/tests/phase6/test_hub_services.py
+++ b/tests/phase6/test_hub_services.py
@@ -1,15 +1,26 @@
 """
 Phase 6 service tests against a running JupyterHub process.
+
+These tests intentionally distinguish between two different JupyterHub routes:
+
+- /hub/api/services/<name> checks Hub service registry metadata.
+- /services/<name> checks the real proxied service endpoint.
+
+The token-acquirer service is a JupyterHub service, so runtime service routing
+must be tested through /services/token-acquirer, not through /hub/api/services.
 """
 
 import httpx
 
 from .conftest import HUB_URL, SERVICE_URL, api_get, read_log, service_names
 
+TOKEN_ACQUIRER_SERVICE_PATH = "/services/token-acquirer"
+TOKEN_ACQUIRER_SERVICE_URL = f"{HUB_URL}{TOKEN_ACQUIRER_SERVICE_PATH}"
+
 
 # phase6-services-1
 # Component: JupyterHub service registry.
-# Purpose: Verify token-acquirer service is registered in the running Hub.
+# Purpose: Verify token-acquirer is registered in the running Hub metadata.
 # Pass example: /hub/api/services includes token-acquirer.
 # Fail example: service configuration is not loaded by Hub.
 def test_running_hub_lists_token_acquirer_service(running_hub):
@@ -21,7 +32,7 @@ def test_running_hub_lists_token_acquirer_service(running_hub):
 
 # phase6-services-2
 # Component: JupyterHub service registry.
-# Purpose: Verify test-admin service is registered in the running Hub.
+# Purpose: Verify test-admin service is registered in the running Hub metadata.
 # Pass example: /hub/api/services includes test-admin.
 # Fail example: the API token service is not registered.
 def test_running_hub_lists_test_admin_service(running_hub):
@@ -32,11 +43,11 @@ def test_running_hub_lists_test_admin_service(running_hub):
 
 
 # phase6-services-3
-# Component: service model.
-# Purpose: Verify token-acquirer has a concrete service model.
-# Pass example: /hub/api/services/token-acquirer returns name and URL.
-# Fail example: service list exists but direct service lookup fails.
-def test_token_acquirer_service_model_is_readable(running_hub):
+# Component: Hub service registry metadata.
+# Purpose: Verify token-acquirer has a concrete Hub service model.
+# Pass example: /hub/api/services/token-acquirer returns name and URL metadata.
+# Fail example: service list exists but direct Hub service lookup fails.
+def test_token_acquirer_service_model_is_readable_from_hub_api(running_hub):
     response = api_get("/hub/api/services/token-acquirer")
 
     assert response.status_code == 200
@@ -46,11 +57,11 @@ def test_token_acquirer_service_model_is_readable(running_hub):
 
 
 # phase6-services-4
-# Component: service model.
-# Purpose: Verify test-admin has a concrete service model.
+# Component: Hub service registry metadata.
+# Purpose: Verify test-admin has a concrete Hub service model.
 # Pass example: /hub/api/services/test-admin returns the service name.
-# Fail example: direct service lookup fails for the test token service.
-def test_test_admin_service_model_is_readable(running_hub):
+# Fail example: direct Hub service lookup fails for the test token service.
+def test_test_admin_service_model_is_readable_from_hub_api(running_hub):
     response = api_get("/hub/api/services/test-admin")
 
     assert response.status_code == 200
@@ -58,17 +69,40 @@ def test_test_admin_service_model_is_readable(running_hub):
 
 
 # phase6-services-5
-# Component: managed Hub service routing.
-# Purpose: Verify token-acquirer is reachable through the Hub proxy.
-# Pass example: the proxied service endpoint does not return a proxy 5xx.
-# Fail example: Hub proxy cannot connect to the managed service process.
-def test_token_acquirer_service_is_reachable_through_hub_proxy(running_hub):
-    response = httpx.get(SERVICE_URL, timeout=5, follow_redirects=False)
+# Component: proxied token-acquirer service route.
+# Purpose: Verify the real token-acquirer route is /services/token-acquirer.
+# Pass example: /services/token-acquirer does not return a Hub proxy 5xx error.
+# Fail example: tests only validate /hub/api metadata and miss service routing.
+def test_token_acquirer_service_is_reachable_through_services_route(running_hub):
+    response = httpx.get(
+        TOKEN_ACQUIRER_SERVICE_URL,
+        timeout=5,
+        follow_redirects=False,
+    )
 
     assert response.status_code not in {502, 503, 504}
 
 
 # phase6-services-6
+# Component: proxied token-acquirer service route.
+# Purpose: Verify SERVICE_URL helper points at the real /services route.
+# Pass example: SERVICE_URL contains /services/token-acquirer.
+# Fail example: helper accidentally points at /hub/api/services/token-acquirer.
+def test_token_acquirer_service_url_helper_uses_services_route(running_hub):
+    assert "/services/token-acquirer" in SERVICE_URL
+    assert "/hub/api/services/token-acquirer" not in SERVICE_URL
+
+
+# phase6-services-7
+# Component: proxied token-acquirer service route.
+# Purpose: Verify the /hub/api service model route is not treated as service UI.
+# Pass example: service runtime tests use /services/token-acquirer.
+# Fail example: runtime route is accidentally changed back to /hub/api/services.
+def test_token_acquirer_runtime_route_is_not_hub_api_route(running_hub):
+    assert TOKEN_ACQUIRER_SERVICE_PATH == "/services/token-acquirer"
+
+
+# phase6-services-8
 # Component: managed service process.
 # Purpose: Verify token-acquirer startup is visible in Hub logs.
 # Pass example: Hub log contains the token-acquirer service name.
@@ -79,19 +113,19 @@ def test_hub_log_mentions_token_acquirer_service(running_hub):
     assert "token-acquirer" in log_text
 
 
-# phase6-services-7
-# Component: service registry authorization.
+# phase6-services-9
+# Component: Hub service registry authorization.
 # Purpose: Verify direct service model lookup requires authentication.
-# Pass example: GET service model without token is rejected.
-# Fail example: anonymous users can inspect service configuration.
+# Pass example: GET /hub/api/services/token-acquirer without token is rejected.
+# Fail example: anonymous users can inspect service metadata.
 def test_token_acquirer_service_model_requires_authentication(running_hub):
     response = api_get("/hub/api/services/token-acquirer", token=False)
 
     assert response.status_code in {403, 404}
 
 
-# phase6-services-8
-# Component: service registry authorization.
+# phase6-services-10
+# Component: Hub service registry metadata.
 # Purpose: Verify missing service lookup returns not found with credentials.
 # Pass example: unknown service name returns HTTP 404.
 # Fail example: unknown service lookup returns a server error.
@@ -101,14 +135,14 @@ def test_missing_service_model_returns_404(running_hub):
     assert response.status_code == 404
 
 
-# phase6-services-9
-# Component: proxied service routing.
-# Purpose: Verify a missing path under the service is not proxy failure.
-# Pass example: service returns app-level 4xx or redirect, not 502.
+# phase6-services-11
+# Component: proxied token-acquirer service route.
+# Purpose: Verify a missing service subpath is not a Hub proxy failure.
+# Pass example: service returns application-level 4xx/redirect, not 502/503/504.
 # Fail example: proxy route exists but service process is unreachable.
 def test_token_acquirer_missing_path_is_not_proxy_failure(running_hub):
     response = httpx.get(
-        f"{SERVICE_URL}missing-path",
+        f"{TOKEN_ACQUIRER_SERVICE_URL}/missing-path",
         timeout=5,
         follow_redirects=False,
     )
@@ -116,24 +150,30 @@ def test_token_acquirer_missing_path_is_not_proxy_failure(running_hub):
     assert response.status_code not in {502, 503, 504}
 
 
-# phase6-services-10
-# Component: proxied service routing.
-# Purpose: Verify repeated requests to the service remain stable.
-# Pass example: several proxied requests avoid proxy 5xx responses.
+# phase6-services-12
+# Component: proxied token-acquirer service route.
+# Purpose: Verify repeated requests to the real service route remain stable.
+# Pass example: several /services/token-acquirer requests avoid proxy 5xx.
 # Fail example: service process exits after the first request.
-def test_token_acquirer_service_handles_repeated_requests(running_hub):
+def test_token_acquirer_service_handles_repeated_services_route_requests(
+    running_hub,
+):
     statuses = []
     for _ in range(3):
-        response = httpx.get(SERVICE_URL, timeout=5, follow_redirects=False)
+        response = httpx.get(
+            TOKEN_ACQUIRER_SERVICE_URL,
+            timeout=5,
+            follow_redirects=False,
+        )
         statuses.append(response.status_code)
 
     assert all(status not in {502, 503, 504} for status in statuses)
 
 
-# phase6-services-11
+# phase6-services-13
 # Component: Hub service API payload.
 # Purpose: Verify service-list payload has expected service names.
-# Pass example: returned service names include the configured services.
+# Pass example: returned service names include the two configured services.
 # Fail example: service registry loses configured services.
 def test_service_list_payload_contains_expected_names(running_hub):
     response = api_get("/hub/api/services")
@@ -142,12 +182,12 @@ def test_service_list_payload_contains_expected_names(running_hub):
     assert {"test-admin", "token-acquirer"}.issubset(names)
 
 
-# phase6-services-12
+# phase6-services-14
 # Component: Hub service model payload.
-# Purpose: Verify token-acquirer model contains expected common fields.
-# Pass example: name and url keys are available.
+# Purpose: Verify token-acquirer registry model contains expected fields.
+# Pass example: name and url keys are available in Hub API metadata.
 # Fail example: Hub service model shape changes unexpectedly.
-def test_token_acquirer_model_contains_expected_fields(running_hub):
+def test_token_acquirer_model_contains_expected_registry_fields(running_hub):
     response = api_get("/hub/api/services/token-acquirer")
     payload = response.json()
 
@@ -155,33 +195,37 @@ def test_token_acquirer_model_contains_expected_fields(running_hub):
     assert "url" in payload
 
 
-# phase6-services-13
+# phase6-services-15
 # Component: Hub service model payload.
-# Purpose: Verify test-admin model contains expected common fields.
-# Pass example: name key is available.
+# Purpose: Verify test-admin registry model contains expected fields.
+# Pass example: name key is available in Hub API metadata.
 # Fail example: Hub service model shape changes unexpectedly.
-def test_test_admin_model_contains_expected_fields(running_hub):
+def test_test_admin_model_contains_expected_registry_fields(running_hub):
     response = api_get("/hub/api/services/test-admin")
     payload = response.json()
 
     assert payload["name"] == "test-admin"
 
 
-# phase6-services-14
+# phase6-services-16
 # Component: proxied service HTTP behavior.
-# Purpose: Verify service root returns a deterministic non-proxy response.
-# Pass example: response is not in proxy error range.
-# Fail example: request is handled by proxy error page.
+# Purpose: Verify service root returns a non-proxy response on the real route.
+# Pass example: /services/token-acquirer is not handled by proxy error page.
+# Fail example: request is handled by proxy 502/503/504 error page.
 def test_token_acquirer_service_root_returns_non_proxy_response(running_hub):
-    response = httpx.get(SERVICE_URL, timeout=5, follow_redirects=False)
+    response = httpx.get(
+        TOKEN_ACQUIRER_SERVICE_URL,
+        timeout=5,
+        follow_redirects=False,
+    )
 
     assert response.status_code not in {502, 503, 504}
 
 
-# phase6-services-15
+# phase6-services-17
 # Component: running Hub service protection.
-# Purpose: Verify service API access with an invalid token is rejected.
-# Pass example: invalid token cannot read service registry.
+# Purpose: Verify service registry API access with an invalid token is rejected.
+# Pass example: invalid token cannot read Hub service registry.
 # Fail example: arbitrary tokens can read service models.
 def test_service_registry_rejects_invalid_token(running_hub):
     response = httpx.get(
@@ -193,20 +237,24 @@ def test_service_registry_rejects_invalid_token(running_hub):
     assert response.status_code in {403, 404}
 
 
-# phase6-services-16
+# phase6-services-18
 # Component: service routing.
-# Purpose: Verify Hub route to token-acquirer stays available after API calls.
-# Pass example: API registry calls do not break proxied service route.
+# Purpose: Verify real service route stays available after registry lookup.
+# Pass example: Hub API metadata lookup does not break /services routing.
 # Fail example: service route disappears after registry access.
 def test_service_route_survives_after_registry_lookup(running_hub):
     registry_response = api_get("/hub/api/services/token-acquirer")
-    service_response = httpx.get(SERVICE_URL, timeout=5, follow_redirects=False)
+    service_response = httpx.get(
+        TOKEN_ACQUIRER_SERVICE_URL,
+        timeout=5,
+        follow_redirects=False,
+    )
 
     assert registry_response.status_code == 200
     assert service_response.status_code not in {502, 503, 504}
 
 
-# phase6-services-17
+# phase6-services-19
 # Component: Hub API service route.
 # Purpose: Verify missing service direct lookup is not server error.
 # Pass example: direct lookup for missing service returns 404.
@@ -217,18 +265,22 @@ def test_missing_service_direct_lookup_is_not_server_error(running_hub):
     assert response.status_code == 404
 
 
-# phase6-services-18
+# phase6-services-20
 # Component: managed service process health.
-# Purpose: Verify Hub process remains alive after service route checks.
+# Purpose: Verify Hub process remains alive after real service route checks.
 # Pass example: Hub process is still running.
 # Fail example: service route checks crash the Hub process.
 def test_hub_process_survives_service_requests(running_hub):
-    httpx.get(SERVICE_URL, timeout=5, follow_redirects=False)
+    httpx.get(
+        TOKEN_ACQUIRER_SERVICE_URL,
+        timeout=5,
+        follow_redirects=False,
+    )
 
     assert running_hub["process"].poll() is None
 
 
-# phase6-services-19
+# phase6-services-21
 # Component: service registry consistency.
 # Purpose: Verify services can be listed twice with stable names.
 # Pass example: repeated service-list calls include the configured services.
@@ -241,13 +293,25 @@ def test_service_registry_is_stable_across_repeated_reads(running_hub):
     assert {"test-admin", "token-acquirer"}.issubset(second)
 
 
-# phase6-services-20
-# Component: Hub service routing.
-# Purpose: Verify service URL from Hub model is internally consistent.
-# Pass example: token-acquirer URL points at localhost test backend.
-# Fail example: service model points at an unexpected backend.
-def test_token_acquirer_service_url_matches_configured_backend(running_hub):
+# phase6-services-22
+# Component: Hub service routing metadata.
+# Purpose: Verify service URL from Hub model points at backend metadata only.
+# Pass example: registry URL is the internal backend URL, not /services path.
+# Fail example: tests confuse backend model URL with public service route.
+def test_token_acquirer_service_model_url_is_backend_metadata(running_hub):
     response = api_get("/hub/api/services/token-acquirer")
     payload = response.json()
 
     assert payload["url"].startswith("http://127.0.0.1:")
+    assert "/services/token-acquirer" not in payload["url"]
+
+
+# phase6-services-23
+# Component: proxied service route correctness.
+# Purpose: Verify the tested public service URL has no /hub/api prefix.
+# Pass example: runtime service URL is http://host/services/token-acquirer.
+# Fail example: runtime service URL is built as /hub/api/services/token-acquirer.
+def test_token_acquirer_public_service_url_has_no_hub_api_prefix(running_hub):
+    assert TOKEN_ACQUIRER_SERVICE_URL.startswith(HUB_URL)
+    assert "/hub/api/" not in TOKEN_ACQUIRER_SERVICE_URL
+    assert TOKEN_ACQUIRER_SERVICE_URL.endswith("/services/token-acquirer")

--- a/tests/phase6/test_hub_services.py
+++ b/tests/phase6/test_hub_services.py
@@ -1,0 +1,253 @@
+"""
+Phase 6 service tests against a running JupyterHub process.
+"""
+
+import httpx
+
+from .conftest import HUB_URL, SERVICE_URL, api_get, read_log, service_names
+
+
+# phase6-services-1
+# Component: JupyterHub service registry.
+# Purpose: Verify token-acquirer service is registered in the running Hub.
+# Pass example: /hub/api/services includes token-acquirer.
+# Fail example: service configuration is not loaded by Hub.
+def test_running_hub_lists_token_acquirer_service(running_hub):
+    response = api_get("/hub/api/services")
+
+    assert response.status_code == 200
+    assert "token-acquirer" in service_names(response.json())
+
+
+# phase6-services-2
+# Component: JupyterHub service registry.
+# Purpose: Verify test-admin service is registered in the running Hub.
+# Pass example: /hub/api/services includes test-admin.
+# Fail example: the API token service is not registered.
+def test_running_hub_lists_test_admin_service(running_hub):
+    response = api_get("/hub/api/services")
+
+    assert response.status_code == 200
+    assert "test-admin" in service_names(response.json())
+
+
+# phase6-services-3
+# Component: service model.
+# Purpose: Verify token-acquirer has a concrete service model.
+# Pass example: /hub/api/services/token-acquirer returns name and URL.
+# Fail example: service list exists but direct service lookup fails.
+def test_token_acquirer_service_model_is_readable(running_hub):
+    response = api_get("/hub/api/services/token-acquirer")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["name"] == "token-acquirer"
+    assert payload["url"].startswith("http://127.0.0.1:")
+
+
+# phase6-services-4
+# Component: service model.
+# Purpose: Verify test-admin has a concrete service model.
+# Pass example: /hub/api/services/test-admin returns the service name.
+# Fail example: direct service lookup fails for the test token service.
+def test_test_admin_service_model_is_readable(running_hub):
+    response = api_get("/hub/api/services/test-admin")
+
+    assert response.status_code == 200
+    assert response.json()["name"] == "test-admin"
+
+
+# phase6-services-5
+# Component: managed Hub service routing.
+# Purpose: Verify token-acquirer is reachable through the Hub proxy.
+# Pass example: the proxied service endpoint does not return a proxy 5xx.
+# Fail example: Hub proxy cannot connect to the managed service process.
+def test_token_acquirer_service_is_reachable_through_hub_proxy(running_hub):
+    response = httpx.get(SERVICE_URL, timeout=5, follow_redirects=False)
+
+    assert response.status_code not in {502, 503, 504}
+
+
+# phase6-services-6
+# Component: managed service process.
+# Purpose: Verify token-acquirer startup is visible in Hub logs.
+# Pass example: Hub log contains the token-acquirer service name.
+# Fail example: managed service command is never started by Hub.
+def test_hub_log_mentions_token_acquirer_service(running_hub):
+    log_text = read_log(running_hub["log_path"])
+
+    assert "token-acquirer" in log_text
+
+
+# phase6-services-7
+# Component: service registry authorization.
+# Purpose: Verify direct service model lookup requires authentication.
+# Pass example: GET service model without token is rejected.
+# Fail example: anonymous users can inspect service configuration.
+def test_token_acquirer_service_model_requires_authentication(running_hub):
+    response = api_get("/hub/api/services/token-acquirer", token=False)
+
+    assert response.status_code in {403, 404}
+
+
+# phase6-services-8
+# Component: service registry authorization.
+# Purpose: Verify missing service lookup returns not found with credentials.
+# Pass example: unknown service name returns HTTP 404.
+# Fail example: unknown service lookup returns a server error.
+def test_missing_service_model_returns_404(running_hub):
+    response = api_get("/hub/api/services/missing-phase6-service")
+
+    assert response.status_code == 404
+
+
+# phase6-services-9
+# Component: proxied service routing.
+# Purpose: Verify a missing path under the service is not proxy failure.
+# Pass example: service returns app-level 4xx or redirect, not 502.
+# Fail example: proxy route exists but service process is unreachable.
+def test_token_acquirer_missing_path_is_not_proxy_failure(running_hub):
+    response = httpx.get(
+        f"{SERVICE_URL}missing-path",
+        timeout=5,
+        follow_redirects=False,
+    )
+
+    assert response.status_code not in {502, 503, 504}
+
+
+# phase6-services-10
+# Component: proxied service routing.
+# Purpose: Verify repeated requests to the service remain stable.
+# Pass example: several proxied requests avoid proxy 5xx responses.
+# Fail example: service process exits after the first request.
+def test_token_acquirer_service_handles_repeated_requests(running_hub):
+    statuses = []
+    for _ in range(3):
+        response = httpx.get(SERVICE_URL, timeout=5, follow_redirects=False)
+        statuses.append(response.status_code)
+
+    assert all(status not in {502, 503, 504} for status in statuses)
+
+
+# phase6-services-11
+# Component: Hub service API payload.
+# Purpose: Verify service-list payload has expected service names.
+# Pass example: returned service names include the configured services.
+# Fail example: service registry loses configured services.
+def test_service_list_payload_contains_expected_names(running_hub):
+    response = api_get("/hub/api/services")
+    names = service_names(response.json())
+
+    assert {"test-admin", "token-acquirer"}.issubset(names)
+
+
+# phase6-services-12
+# Component: Hub service model payload.
+# Purpose: Verify token-acquirer model contains expected common fields.
+# Pass example: name and url keys are available.
+# Fail example: Hub service model shape changes unexpectedly.
+def test_token_acquirer_model_contains_expected_fields(running_hub):
+    response = api_get("/hub/api/services/token-acquirer")
+    payload = response.json()
+
+    assert payload["name"] == "token-acquirer"
+    assert "url" in payload
+
+
+# phase6-services-13
+# Component: Hub service model payload.
+# Purpose: Verify test-admin model contains expected common fields.
+# Pass example: name key is available.
+# Fail example: Hub service model shape changes unexpectedly.
+def test_test_admin_model_contains_expected_fields(running_hub):
+    response = api_get("/hub/api/services/test-admin")
+    payload = response.json()
+
+    assert payload["name"] == "test-admin"
+
+
+# phase6-services-14
+# Component: proxied service HTTP behavior.
+# Purpose: Verify service root returns a deterministic non-proxy response.
+# Pass example: response is not in proxy error range.
+# Fail example: request is handled by proxy error page.
+def test_token_acquirer_service_root_returns_non_proxy_response(running_hub):
+    response = httpx.get(SERVICE_URL, timeout=5, follow_redirects=False)
+
+    assert response.status_code not in {502, 503, 504}
+
+
+# phase6-services-15
+# Component: running Hub service protection.
+# Purpose: Verify service API access with an invalid token is rejected.
+# Pass example: invalid token cannot read service registry.
+# Fail example: arbitrary tokens can read service models.
+def test_service_registry_rejects_invalid_token(running_hub):
+    response = httpx.get(
+        f"{HUB_URL}/hub/api/services",
+        headers={"Authorization": "token invalid-token"},
+        timeout=5,
+    )
+
+    assert response.status_code in {403, 404}
+
+
+# phase6-services-16
+# Component: service routing.
+# Purpose: Verify Hub route to token-acquirer stays available after API calls.
+# Pass example: API registry calls do not break proxied service route.
+# Fail example: service route disappears after registry access.
+def test_service_route_survives_after_registry_lookup(running_hub):
+    registry_response = api_get("/hub/api/services/token-acquirer")
+    service_response = httpx.get(SERVICE_URL, timeout=5, follow_redirects=False)
+
+    assert registry_response.status_code == 200
+    assert service_response.status_code not in {502, 503, 504}
+
+
+# phase6-services-17
+# Component: Hub API service route.
+# Purpose: Verify missing service direct lookup is not server error.
+# Pass example: direct lookup for missing service returns 404.
+# Fail example: direct lookup raises 5xx.
+def test_missing_service_direct_lookup_is_not_server_error(running_hub):
+    response = api_get("/hub/api/services/does-not-exist")
+
+    assert response.status_code == 404
+
+
+# phase6-services-18
+# Component: managed service process health.
+# Purpose: Verify Hub process remains alive after service route checks.
+# Pass example: Hub process is still running.
+# Fail example: service route checks crash the Hub process.
+def test_hub_process_survives_service_requests(running_hub):
+    httpx.get(SERVICE_URL, timeout=5, follow_redirects=False)
+
+    assert running_hub["process"].poll() is None
+
+
+# phase6-services-19
+# Component: service registry consistency.
+# Purpose: Verify services can be listed twice with stable names.
+# Pass example: repeated service-list calls include the configured services.
+# Fail example: service registry changes unexpectedly between calls.
+def test_service_registry_is_stable_across_repeated_reads(running_hub):
+    first = service_names(api_get("/hub/api/services").json())
+    second = service_names(api_get("/hub/api/services").json())
+
+    assert {"test-admin", "token-acquirer"}.issubset(first)
+    assert {"test-admin", "token-acquirer"}.issubset(second)
+
+
+# phase6-services-20
+# Component: Hub service routing.
+# Purpose: Verify service URL from Hub model is internally consistent.
+# Pass example: token-acquirer URL points at localhost test backend.
+# Fail example: service model points at an unexpected backend.
+def test_token_acquirer_service_url_matches_configured_backend(running_hub):
+    response = api_get("/hub/api/services/token-acquirer")
+    payload = response.json()
+
+    assert payload["url"].startswith("http://127.0.0.1:")

--- a/tests/phase6/test_hub_smoke.py
+++ b/tests/phase6/test_hub_smoke.py
@@ -1,0 +1,189 @@
+"""
+Phase 6 smoke tests for a running JupyterHub process.
+"""
+
+import httpx
+
+from .conftest import HUB_URL, api_get, auth_headers, read_log
+
+
+# phase6-smoke-1
+# Component: running JupyterHub API.
+# Purpose: Verify that JupyterHub starts and returns version information.
+# Pass example: GET /hub/api returns HTTP 200 and contains a version field.
+# Fail example: Hub startup or proxy routing is broken.
+def test_running_hub_api_returns_version(running_hub):
+    response = api_get("/hub/api")
+
+    assert response.status_code == 200
+    assert "version" in response.json()
+
+
+# phase6-smoke-2
+# Component: public Hub API root.
+# Purpose: Document that /hub/api is an informational endpoint.
+# Pass example: GET /hub/api without token returns HTTP 200.
+# Fail example: Hub behavior changes and the endpoint becomes protected.
+def test_running_hub_api_root_is_public(running_hub):
+    response = api_get("/hub/api", token=False)
+
+    assert response.status_code == 200
+    assert "version" in response.json()
+
+
+# phase6-smoke-3
+# Component: protected Hub users API.
+# Purpose: Verify protected API endpoints reject missing credentials.
+# Pass example: GET /hub/api/users without token is forbidden or hidden.
+# Fail example: user list can be read anonymously.
+def test_running_hub_users_api_requires_authentication(running_hub):
+    response = api_get("/hub/api/users", token=False)
+
+    assert response.status_code in {403, 404}
+
+
+# phase6-smoke-4
+# Component: protected Hub services API.
+# Purpose: Verify service registry access rejects missing credentials.
+# Pass example: GET /hub/api/services without token is forbidden or hidden.
+# Fail example: service registry can be read anonymously.
+def test_running_hub_services_api_requires_authentication(running_hub):
+    response = api_get("/hub/api/services", token=False)
+
+    assert response.status_code in {403, 404}
+
+
+# phase6-smoke-5
+# Component: configured test service token.
+# Purpose: Verify the service token has enough access to list users.
+# Pass example: GET /hub/api/users with token returns HTTP 200.
+# Fail example: the configured service role is too weak.
+def test_running_hub_service_token_can_list_users(running_hub):
+    response = api_get("/hub/api/users")
+
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+
+
+# phase6-smoke-6
+# Component: configured test service token.
+# Purpose: Verify the service token has enough access to list services.
+# Pass example: GET /hub/api/services with token returns HTTP 200.
+# Fail example: service role lacks service-read permissions.
+def test_running_hub_service_token_can_list_services(running_hub):
+    response = api_get("/hub/api/services")
+
+    assert response.status_code == 200
+
+
+# phase6-smoke-7
+# Component: Hub login route.
+# Purpose: Verify that the web-facing Hub route is reachable.
+# Pass example: /hub/login returns a successful page or redirect.
+# Fail example: proxy cannot route ordinary Hub web requests.
+def test_running_hub_login_route_is_reachable(running_hub):
+    response = httpx.get(
+        f"{HUB_URL}/hub/login",
+        timeout=5,
+        follow_redirects=False,
+    )
+
+    assert response.status_code in {200, 302, 303}
+
+
+# phase6-smoke-8
+# Component: Hub root routing.
+# Purpose: Verify that the proxy can route requests to the Hub base path.
+# Pass example: /hub/ returns a normal page or redirect.
+# Fail example: proxy routing to Hub base path is broken.
+def test_running_hub_base_route_is_reachable(running_hub):
+    response = httpx.get(
+        f"{HUB_URL}/hub/",
+        timeout=5,
+        follow_redirects=False,
+    )
+
+    assert response.status_code in {200, 302, 303}
+
+
+# phase6-smoke-9
+# Component: Hub API token rejection.
+# Purpose: Verify that invalid tokens do not get API access.
+# Pass example: invalid token does not return HTTP 200 for /hub/api/users.
+# Fail example: Hub accepts arbitrary bearer tokens.
+def test_running_hub_rejects_invalid_service_token(running_hub):
+    response = httpx.get(
+        f"{HUB_URL}/hub/api/users",
+        headers={"Authorization": "token invalid-token"},
+        timeout=5,
+    )
+
+    assert response.status_code in {403, 404}
+
+
+# phase6-smoke-10
+# Component: Hub startup quality.
+# Purpose: Verify that Hub startup log does not contain Python tracebacks.
+# Pass example: Hub and managed services start without tracebacks.
+# Fail example: Hub config or service startup raises an exception.
+def test_running_hub_log_has_no_traceback(running_hub):
+    log_text = read_log(running_hub["log_path"])
+
+    assert "Traceback (most recent call last)" not in log_text
+
+
+# phase6-smoke-11
+# Component: Hub process management.
+# Purpose: Verify the fixture keeps Hub running during the test session.
+# Pass example: process.poll() is None while tests are running.
+# Fail example: Hub exits after startup.
+def test_running_hub_process_is_alive(running_hub):
+    assert running_hub["process"].poll() is None
+
+
+# phase6-smoke-12
+# Component: Hub API response content.
+# Purpose: Verify Hub API returns JSON for the root API endpoint.
+# Pass example: content-type contains application/json.
+# Fail example: proxy returns an HTML error page.
+def test_running_hub_api_returns_json_content_type(running_hub):
+    response = api_get("/hub/api")
+
+    assert "application/json" in response.headers["content-type"]
+
+
+# phase6-smoke-13
+# Component: Hub API authorization header handling.
+# Purpose: Verify the configured token works with the expected header.
+# Pass example: Authorization: token phase6-test-admin-token returns 200.
+# Fail example: token format no longer matches Hub expectations.
+def test_running_hub_accepts_expected_authorization_header(running_hub):
+    response = httpx.get(
+        f"{HUB_URL}/hub/api/users",
+        headers=auth_headers(),
+        timeout=5,
+    )
+
+    assert response.status_code == 200
+
+
+# phase6-smoke-14
+# Component: Hub API path protection.
+# Purpose: Verify a non-root protected endpoint is protected without token.
+# Pass example: GET /hub/api/groups without token is forbidden or hidden.
+# Fail example: group list can be read anonymously.
+def test_running_hub_groups_api_requires_authentication(running_hub):
+    response = api_get("/hub/api/groups", token=False)
+
+    assert response.status_code in {403, 404}
+
+
+# phase6-smoke-15
+# Component: Hub API group listing.
+# Purpose: Verify the configured token can access the group API.
+# Pass example: GET /hub/api/groups returns HTTP 200.
+# Fail example: service token lacks group-read permissions.
+def test_running_hub_service_token_can_list_groups(running_hub):
+    response = api_get("/hub/api/groups")
+
+    assert response.status_code == 200

--- a/tests/phase6/test_hub_spawner.py
+++ b/tests/phase6/test_hub_spawner.py
@@ -1,0 +1,278 @@
+"""
+Phase 6 spawner lifecycle tests against a running JupyterHub process.
+"""
+
+import json
+import time
+from pathlib import Path
+
+import httpx
+
+from .conftest import HUB_URL, api_delete, api_get, api_post, create_user, delete_user
+
+
+def _events_path(running_hub):
+    return Path(running_hub["log_path"]).parent / "spawner-events.jsonl"
+
+
+def _read_spawner_events(running_hub):
+    path = _events_path(running_hub)
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _events_for_user(running_hub, username):
+    return [
+        event
+        for event in _read_spawner_events(running_hub)
+        if event.get("user") == username
+    ]
+
+
+def _wait_for_event(running_hub, username, event_name, timeout=30):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        matching = [
+            event
+            for event in _events_for_user(running_hub, username)
+            if event.get("event") == event_name
+        ]
+        if matching:
+            return matching[-1]
+        time.sleep(0.5)
+
+    raise AssertionError(f"Missing spawner event {event_name!r} for {username!r}")
+
+
+def _wait_for_server_ready(username, timeout=45):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        response = api_get(f"/hub/api/users/{username}")
+        if response.status_code == 200:
+            user_model = response.json()
+            default_server = user_model.get("servers", {}).get("", {})
+            if default_server.get("ready") is True:
+                return user_model
+        time.sleep(0.5)
+
+    raise AssertionError(f"Server for {username!r} did not become ready")
+
+
+def _start_default_server(username):
+    response = api_post(f"/hub/api/users/{username}/server")
+    assert response.status_code in {201, 202, 204}
+    return response
+
+
+def _stop_default_server(username):
+    response = api_delete(f"/hub/api/users/{username}/server")
+    assert response.status_code in {202, 204, 404}
+    return response
+
+
+def _spawn_user(running_hub, username):
+    create_user(username)
+    _start_default_server(username)
+    event = _wait_for_event(running_hub, username, "start")
+    user_model = _wait_for_server_ready(username)
+    return event, user_model
+
+
+def _cleanup_user(username):
+    _stop_default_server(username)
+    delete_user(username)
+
+
+# phase6-spawner-1
+# Component: running Hub + EGISpawner lifecycle.
+# Purpose: Verify a Hub spawn request reaches the configured EGISpawner subclass.
+# Pass example: POST /hub/api/users/<name>/server records a start event.
+# Fail example: Hub does not instantiate the configured spawner class.
+def test_running_hub_spawn_request_reaches_egi_spawner(running_hub, unique_name):
+    event, _ = _spawn_user(running_hub, unique_name)
+
+    assert event["event"] == "start"
+    assert event["user"] == unique_name
+    assert event["spawner_class"] == "Phase6RecordingEGISpawner"
+    _cleanup_user(unique_name)
+
+
+# phase6-spawner-2
+# Component: running Hub + user server model.
+# Purpose: Verify Hub marks the spawned default server as ready.
+# Pass example: user model contains servers[""].ready == True.
+# Fail example: spawner start returns but Hub never observes the server.
+def test_running_hub_spawned_server_becomes_ready(running_hub, unique_name):
+    _, user_model = _spawn_user(running_hub, unique_name)
+
+    assert user_model["servers"][""]["ready"] is True
+    _cleanup_user(unique_name)
+
+
+# phase6-spawner-3
+# Component: running Hub + proxy routing.
+# Purpose: Verify the spawned user route is routed to the test server backend.
+# Pass example: the request reaches the backend and does not return proxy 5xx.
+# Fail example: Hub starts the server but proxy routing is unavailable.
+def test_running_hub_spawned_user_route_is_reachable(running_hub, unique_name):
+    _spawn_user(running_hub, unique_name)
+
+    response = httpx.get(
+        f"{HUB_URL}/user/{unique_name}/",
+        timeout=5,
+        follow_redirects=True,
+    )
+
+    # The lightweight http.server backend does not implement JupyterHub base_url
+    # path handling, so it may return 404 for /user/<name>/. A 404 response from
+    # the backend still proves that Hub proxy routing reached the spawned server.
+    assert response.status_code not in {502, 503, 504}
+    _cleanup_user(unique_name)
+
+
+# phase6-spawner-4
+# Component: running Hub + EGISpawner configuration.
+# Purpose: Verify initialized spawner records generated token Secret name.
+# Pass example: start event contains an access-token-* Secret name.
+# Fail example: Hub uses a different spawner or skips EGI initialization.
+def test_running_hub_spawner_records_token_secret_name(running_hub, unique_name):
+    event, _ = _spawn_user(running_hub, unique_name)
+
+    assert event["token_secret_name"].startswith("access-token-")
+    _cleanup_user(unique_name)
+
+
+# phase6-spawner-5
+# Component: running Hub + EGISpawner configuration.
+# Purpose: Verify initialized spawner records generated token Secret volume name.
+# Pass example: start event contains a secret-* volume name.
+# Fail example: EGI token volume initialization is skipped.
+def test_running_hub_spawner_records_token_secret_volume_name(
+    running_hub,
+    unique_name,
+):
+    event, _ = _spawn_user(running_hub, unique_name)
+
+    assert event["token_secret_volume_name"].startswith("secret-")
+    _cleanup_user(unique_name)
+
+
+# phase6-spawner-6
+# Component: running Hub + EGISpawner configuration.
+# Purpose: Verify initialized spawner records the configured token mount path.
+# Pass example: start event contains /var/run/secrets/egi.eu/.
+# Fail example: Hub-loaded spawner loses EGI token mount configuration.
+def test_running_hub_spawner_records_token_mount_path(running_hub, unique_name):
+    event, _ = _spawn_user(running_hub, unique_name)
+
+    assert event["token_mount_path"] == "/var/run/secrets/egi.eu/"
+    _cleanup_user(unique_name)
+
+
+# phase6-spawner-7
+# Component: running Hub + EGISpawner PVC initialization.
+# Purpose: Verify initialized spawner records a generated pvc_name.
+# Pass example: pvc_name is present and non-empty.
+# Fail example: EGISpawner initialization did not run in Hub context.
+def test_running_hub_spawner_records_generated_pvc_name(running_hub, unique_name):
+    event, _ = _spawn_user(running_hub, unique_name)
+
+    assert isinstance(event["pvc_name"], str)
+    assert event["pvc_name"]
+    _cleanup_user(unique_name)
+
+
+# phase6-spawner-8
+# Component: running Hub + spawner stop lifecycle.
+# Purpose: Verify deleting the server reaches the spawner stop method.
+# Pass example: DELETE /hub/api/users/<name>/server records a stop event.
+# Fail example: Hub removes state without calling spawner cleanup.
+def test_running_hub_server_delete_reaches_spawner_stop(running_hub, unique_name):
+    _spawn_user(running_hub, unique_name)
+
+    _stop_default_server(unique_name)
+    event = _wait_for_event(running_hub, unique_name, "stop")
+
+    assert event["event"] == "stop"
+    delete_user(unique_name)
+
+
+# phase6-spawner-9
+# Component: running Hub + repeated lifecycle.
+# Purpose: Verify the same user can spawn again after stopping.
+# Pass example: two start events are recorded for the same user.
+# Fail example: stale state prevents a second spawn.
+def test_running_hub_user_can_spawn_again_after_stop(running_hub, unique_name):
+    _spawn_user(running_hub, unique_name)
+    _stop_default_server(unique_name)
+
+    _start_default_server(unique_name)
+    _wait_for_server_ready(unique_name)
+
+    start_events = [
+        event
+        for event in _events_for_user(running_hub, unique_name)
+        if event["event"] == "start"
+    ]
+
+    assert len(start_events) >= 2
+    _cleanup_user(unique_name)
+
+
+# phase6-spawner-10
+# Component: running Hub + missing user spawn handling.
+# Purpose: Verify spawn request for a missing user is rejected cleanly.
+# Pass example: Hub returns 4xx, not 5xx.
+# Fail example: missing user spawn crashes Hub.
+def test_running_hub_spawn_missing_user_is_rejected_cleanly(
+    running_hub,
+    unique_name,
+):
+    response = api_post(f"/hub/api/users/{unique_name}/server")
+
+    assert 400 <= response.status_code < 500
+
+
+# phase6-spawner-11
+# Component: running Hub + multi-user spawner lifecycle.
+# Purpose: Verify two users get separate spawner start events.
+# Pass example: each user records its own start event and generated Secret name.
+# Fail example: spawner state leaks between users.
+def test_running_hub_two_users_get_separate_spawner_events(
+    running_hub,
+    unique_name,
+):
+    first = f"{unique_name}-a"
+    second = f"{unique_name}-b"
+
+    first_event, _ = _spawn_user(running_hub, first)
+    second_event, _ = _spawn_user(running_hub, second)
+
+    assert first_event["user"] == first
+    assert second_event["user"] == second
+    assert first_event["token_secret_name"].startswith("access-token-")
+    assert second_event["token_secret_name"].startswith("access-token-")
+    assert first_event["token_secret_name"] != second_event["token_secret_name"]
+
+    _cleanup_user(first)
+    _cleanup_user(second)
+
+
+# phase6-spawner-12
+# Component: running Hub + process stability.
+# Purpose: Verify Hub process survives spawn and stop lifecycle operations.
+# Pass example: process.poll() is None after lifecycle operations.
+# Fail example: spawner lifecycle crashes the Hub process.
+def test_running_hub_process_survives_spawner_lifecycle(
+    running_hub,
+    unique_name,
+):
+    _spawn_user(running_hub, unique_name)
+    _cleanup_user(unique_name)
+
+    assert running_hub["process"].poll() is None

--- a/tests/phase6/test_hub_spawner_extended.py
+++ b/tests/phase6/test_hub_spawner_extended.py
@@ -1,0 +1,658 @@
+"""
+Additional Phase 6 spawner lifecycle tests against a running JupyterHub process.
+"""
+
+import json
+import time
+from pathlib import Path
+
+import httpx
+
+from .conftest import HUB_URL, api_delete, api_get, api_post, create_user, delete_user
+
+
+def _events_path(running_hub):
+    return Path(running_hub["log_path"]).parent / "spawner-events.jsonl"
+
+
+def _read_spawner_events(running_hub):
+    path = _events_path(running_hub)
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _events_for_user(running_hub, username, server_name=None):
+    events = [
+        event
+        for event in _read_spawner_events(running_hub)
+        if event.get("user") == username
+    ]
+    if server_name is not None:
+        events = [
+            event for event in events if event.get("server_name", "") == server_name
+        ]
+    return events
+
+
+def _wait_for_event_count(
+    running_hub,
+    username,
+    event_name,
+    count,
+    *,
+    server_name=None,
+    timeout=45,
+):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        matching = [
+            event
+            for event in _events_for_user(running_hub, username, server_name)
+            if event.get("event") == event_name
+        ]
+        if len(matching) >= count:
+            return matching
+        time.sleep(0.5)
+
+    raise AssertionError(f"Expected {count} {event_name!r} events for {username!r}")
+
+
+def _wait_for_event(running_hub, username, event_name, *, server_name=None, timeout=45):
+    return _wait_for_event_count(
+        running_hub,
+        username,
+        event_name,
+        1,
+        server_name=server_name,
+        timeout=timeout,
+    )[-1]
+
+
+def _wait_for_server_ready(username, server_name="", timeout=45):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        response = api_get(f"/hub/api/users/{username}")
+        if response.status_code == 200:
+            user_model = response.json()
+            server = user_model.get("servers", {}).get(server_name, {})
+            if server.get("ready") is True:
+                return user_model
+        time.sleep(0.5)
+
+    raise AssertionError(
+        f"Server {server_name!r} for {username!r} did not become ready"
+    )
+
+
+def _server_api_path(username, server_name=""):
+    if server_name:
+        return f"/hub/api/users/{username}/servers/{server_name}"
+    return f"/hub/api/users/{username}/server"
+
+
+def _start_server(username, server_name=""):
+    response = api_post(_server_api_path(username, server_name))
+    assert response.status_code in {201, 202, 204}
+    return response
+
+
+def _stop_server(username, server_name=""):
+    response = api_delete(_server_api_path(username, server_name))
+    assert response.status_code in {202, 204, 404}
+    return response
+
+
+def _spawn_user(running_hub, username, server_name=""):
+    create_user(username)
+    _start_server(username, server_name)
+    event = _wait_for_event(
+        running_hub,
+        username,
+        "start",
+        server_name=server_name,
+    )
+    user_model = _wait_for_server_ready(username, server_name)
+    return event, user_model
+
+
+def _cleanup_user(username):
+    api_delete(f"/hub/api/users/{username}/servers/named")
+    api_delete(f"/hub/api/users/{username}/server")
+    delete_user(username)
+
+
+# phase6-spawner-ext-1
+# Component: Hub API authorization.
+# Purpose: Verify anonymous clients cannot start a default user server.
+# Pass example: POST without token returns 403 or 404.
+# Fail example: anonymous clients can spawn servers.
+def test_anonymous_client_cannot_start_default_server(running_hub, unique_name):
+    create_user(unique_name)
+
+    response = httpx.post(f"{HUB_URL}/hub/api/users/{unique_name}/server", timeout=5)
+
+    assert response.status_code in {403, 404}
+    delete_user(unique_name)
+
+
+# phase6-spawner-ext-2
+# Component: Hub API authorization.
+# Purpose: Verify anonymous clients cannot stop a default user server.
+# Pass example: DELETE without token returns 403 or 404.
+# Fail example: anonymous clients can stop servers.
+def test_anonymous_client_cannot_stop_default_server(running_hub, unique_name):
+    _spawn_user(running_hub, unique_name)
+
+    response = httpx.delete(f"{HUB_URL}/hub/api/users/{unique_name}/server", timeout=5)
+
+    assert response.status_code in {403, 404}
+    _cleanup_user(unique_name)
+
+
+# phase6-spawner-ext-3
+# Component: Hub API authorization.
+# Purpose: Verify invalid tokens cannot start a default user server.
+# Pass example: invalid token returns 403 or 404.
+# Fail example: arbitrary tokens can spawn servers.
+def test_invalid_token_cannot_start_default_server(running_hub, unique_name):
+    create_user(unique_name)
+
+    response = httpx.post(
+        f"{HUB_URL}/hub/api/users/{unique_name}/server",
+        headers={"Authorization": "token invalid-token"},
+        timeout=5,
+    )
+
+    assert response.status_code in {403, 404}
+    delete_user(unique_name)
+
+
+# phase6-spawner-ext-4
+# Component: Hub API authorization.
+# Purpose: Verify invalid tokens cannot stop a default user server.
+# Pass example: invalid token returns 403 or 404.
+# Fail example: arbitrary tokens can stop servers.
+def test_invalid_token_cannot_stop_default_server(running_hub, unique_name):
+    _spawn_user(running_hub, unique_name)
+
+    response = httpx.delete(
+        f"{HUB_URL}/hub/api/users/{unique_name}/server",
+        headers={"Authorization": "token invalid-token"},
+        timeout=5,
+    )
+
+    assert response.status_code in {403, 404}
+    _cleanup_user(unique_name)
+
+
+# phase6-spawner-ext-5
+# Component: Hub API authorization.
+# Purpose: Verify anonymous clients cannot start a named server.
+# Pass example: POST named server without token returns 403 or 404.
+# Fail example: anonymous clients can create named servers.
+def test_anonymous_client_cannot_start_named_server(running_hub, unique_name):
+    create_user(unique_name)
+
+    response = httpx.post(
+        f"{HUB_URL}/hub/api/users/{unique_name}/servers/named",
+        timeout=5,
+    )
+
+    assert response.status_code in {403, 404}
+    delete_user(unique_name)
+
+
+# phase6-spawner-ext-6
+# Component: running Hub + named server lifecycle.
+# Purpose: Verify a named server spawn reaches the EGI spawner subclass.
+# Pass example: POST /servers/named records a start event.
+# Fail example: named server requests bypass the configured spawner.
+def test_running_hub_named_server_spawn_reaches_spawner(running_hub, unique_name):
+    event, user_model = _spawn_user(running_hub, unique_name, "named")
+
+    assert event["event"] == "start"
+    assert event["server_name"] == "named"
+    assert "named" in user_model["servers"]
+    assert user_model["servers"]["named"]["ready"] is True
+    _cleanup_user(unique_name)
+
+
+# phase6-spawner-ext-7
+# Component: running Hub + named server model.
+# Purpose: Verify named server appears separately from the default server.
+# Pass example: servers contains named and does not require default server.
+# Fail example: named server state is stored under the default server key.
+def test_running_hub_named_server_has_separate_model_key(
+    running_hub,
+    unique_name,
+):
+    _, user_model = _spawn_user(running_hub, unique_name, "named")
+
+    assert "named" in user_model["servers"]
+    assert "" not in user_model["servers"]
+    _cleanup_user(unique_name)
+
+
+# phase6-spawner-ext-8
+# Component: running Hub + named server stop.
+# Purpose: Verify named server deletion reaches the spawner stop method.
+# Pass example: DELETE /servers/named records a stop event.
+# Fail example: named server cleanup skips spawner.stop().
+def test_running_hub_named_server_stop_reaches_spawner(running_hub, unique_name):
+    _spawn_user(running_hub, unique_name, "named")
+
+    _stop_server(unique_name, "named")
+    stop_events = _wait_for_event_count(
+        running_hub,
+        unique_name,
+        "stop",
+        1,
+        server_name="named",
+    )
+
+    assert stop_events[-1]["event"] == "stop"
+    assert stop_events[-1]["server_name"] == "named"
+    delete_user(unique_name)
+
+
+# phase6-spawner-ext-9
+# Component: running Hub + named server cleanup.
+# Purpose: Verify named server model is removed after stop.
+# Pass example: servers no longer contains named after DELETE.
+# Fail example: stopped named server remains ready in Hub model.
+def test_running_hub_named_server_model_updates_after_stop(
+    running_hub,
+    unique_name,
+):
+    _spawn_user(running_hub, unique_name, "named")
+
+    _stop_server(unique_name, "named")
+    response = api_get(f"/hub/api/users/{unique_name}")
+    servers = response.json().get("servers", {})
+
+    assert "named" not in servers or servers["named"].get("ready") is not True
+    delete_user(unique_name)
+
+
+# phase6-spawner-ext-10
+# Component: running Hub + named server route.
+# Purpose: Verify named server route reaches a backend and avoids proxy 5xx.
+# Pass example: /user/<name>/named/ does not return 502, 503, or 504.
+# Fail example: named server route is not registered in the proxy.
+def test_running_hub_named_server_route_is_not_proxy_failure(
+    running_hub,
+    unique_name,
+):
+    _spawn_user(running_hub, unique_name, "named")
+
+    response = httpx.get(
+        f"{HUB_URL}/user/{unique_name}/named/",
+        timeout=5,
+        follow_redirects=True,
+    )
+
+    assert response.status_code not in {502, 503, 504}
+    _cleanup_user(unique_name)
+
+
+# phase6-spawner-ext-11
+# Component: spawner event payload.
+# Purpose: Verify start event contains a process id and port.
+# Pass example: pid and port are positive integers.
+# Fail example: spawner start did not record backend process metadata.
+def test_spawner_start_event_records_pid_and_port(running_hub, unique_name):
+    event, _ = _spawn_user(running_hub, unique_name)
+
+    assert isinstance(event["pid"], int)
+    assert event["pid"] > 0
+    assert isinstance(event["port"], int)
+    assert event["port"] > 0
+    _cleanup_user(unique_name)
+
+
+# phase6-spawner-ext-12
+# Component: spawner event payload.
+# Purpose: Verify start event contains a numeric timestamp.
+# Pass example: timestamp is an int or float.
+# Fail example: event logging omits ordering metadata.
+def test_spawner_start_event_records_timestamp(running_hub, unique_name):
+    event, _ = _spawn_user(running_hub, unique_name)
+
+    assert isinstance(event["timestamp"], (int, float))
+    assert event["timestamp"] > 0
+    _cleanup_user(unique_name)
+
+
+# phase6-spawner-ext-13
+# Component: spawner event payload.
+# Purpose: Verify stop event records the stop mode.
+# Pass example: stop event contains now=False for normal deletion.
+# Fail example: spawner stop metadata is missing.
+def test_spawner_stop_event_records_now_flag(running_hub, unique_name):
+    _spawn_user(running_hub, unique_name)
+
+    _stop_server(unique_name)
+    event = _wait_for_event(running_hub, unique_name, "stop")
+
+    assert event["now"] is False
+    delete_user(unique_name)
+
+
+# phase6-spawner-ext-14
+# Component: spawner event payload.
+# Purpose: Verify generated Secret names differ between users.
+# Pass example: separate users have different token_secret_name values.
+# Fail example: spawner state is shared across users.
+def test_spawner_token_secret_names_differ_between_users(
+    running_hub,
+    unique_name,
+):
+    first = f"{unique_name}-a"
+    second = f"{unique_name}-b"
+
+    first_event, _ = _spawn_user(running_hub, first)
+    second_event, _ = _spawn_user(running_hub, second)
+
+    assert first_event["token_secret_name"] != second_event["token_secret_name"]
+    _cleanup_user(first)
+    _cleanup_user(second)
+
+
+# phase6-spawner-ext-15
+# Component: spawner event payload.
+# Purpose: Verify generated Secret volume names differ between users.
+# Pass example: separate users have different token_secret_volume_name values.
+# Fail example: generated volume names collide across users.
+def test_spawner_token_secret_volume_names_differ_between_users(
+    running_hub,
+    unique_name,
+):
+    first = f"{unique_name}-a"
+    second = f"{unique_name}-b"
+
+    first_event, _ = _spawn_user(running_hub, first)
+    second_event, _ = _spawn_user(running_hub, second)
+
+    assert (
+        first_event["token_secret_volume_name"]
+        != second_event["token_secret_volume_name"]
+    )
+    _cleanup_user(first)
+    _cleanup_user(second)
+
+
+# phase6-spawner-ext-16
+# Component: server stop idempotency.
+# Purpose: Verify stopping an already stopped default server is stable.
+# Pass example: second DELETE returns a non-5xx status.
+# Fail example: repeated stop crashes Hub.
+def test_default_server_stop_is_idempotent(running_hub, unique_name):
+    _spawn_user(running_hub, unique_name)
+
+    first = _stop_server(unique_name)
+    second = api_delete(f"/hub/api/users/{unique_name}/server")
+
+    assert first.status_code in {202, 204, 404}
+    assert second.status_code < 500
+    delete_user(unique_name)
+
+
+# phase6-spawner-ext-17
+# Component: server stop idempotency.
+# Purpose: Verify stopping an already stopped named server is stable.
+# Pass example: second DELETE returns a non-5xx status.
+# Fail example: repeated named server stop crashes Hub.
+def test_named_server_stop_is_idempotent(running_hub, unique_name):
+    _spawn_user(running_hub, unique_name, "named")
+
+    first = _stop_server(unique_name, "named")
+    second = api_delete(f"/hub/api/users/{unique_name}/servers/named")
+
+    assert first.status_code in {202, 204, 404}
+    assert second.status_code < 500
+    delete_user(unique_name)
+
+
+# phase6-spawner-ext-18
+# Component: duplicate spawn handling.
+# Purpose: Verify duplicate default server spawn is stable.
+# Pass example: second POST returns a non-5xx status.
+# Fail example: duplicate spawn crashes Hub.
+def test_duplicate_default_server_spawn_is_stable(running_hub, unique_name):
+    _spawn_user(running_hub, unique_name)
+
+    response = api_post(f"/hub/api/users/{unique_name}/server")
+
+    assert response.status_code < 500
+    _cleanup_user(unique_name)
+
+
+# phase6-spawner-ext-19
+# Component: duplicate spawn handling.
+# Purpose: Verify duplicate named server spawn is stable.
+# Pass example: second POST returns a non-5xx status.
+# Fail example: duplicate named server spawn crashes Hub.
+def test_duplicate_named_server_spawn_is_stable(running_hub, unique_name):
+    _spawn_user(running_hub, unique_name, "named")
+
+    response = api_post(f"/hub/api/users/{unique_name}/servers/named")
+
+    assert response.status_code < 500
+    _cleanup_user(unique_name)
+
+
+# phase6-spawner-ext-20
+# Component: cleanup behavior.
+# Purpose: Verify deleted users disappear from direct lookup after server cleanup.
+# Pass example: GET user after cleanup returns HTTP 404.
+# Fail example: user remains in Hub database after deletion.
+def test_user_disappears_after_server_cleanup_and_delete(
+    running_hub,
+    unique_name,
+):
+    _spawn_user(running_hub, unique_name)
+
+    _cleanup_user(unique_name)
+    response = api_get(f"/hub/api/users/{unique_name}")
+
+    assert response.status_code == 404
+
+
+# phase6-spawner-ext-21
+# Component: cleanup behavior.
+# Purpose: Verify user deletion after a named server cleanup removes the user.
+# Pass example: GET user after named server cleanup returns HTTP 404.
+# Fail example: named server state prevents user deletion.
+def test_user_disappears_after_named_server_cleanup_and_delete(
+    running_hub,
+    unique_name,
+):
+    _spawn_user(running_hub, unique_name, "named")
+
+    _cleanup_user(unique_name)
+    response = api_get(f"/hub/api/users/{unique_name}")
+
+    assert response.status_code == 404
+
+
+# phase6-spawner-ext-22
+# Component: multi-user lifecycle.
+# Purpose: Verify three sequential users receive three distinct backend ports.
+# Pass example: each start event has a different port.
+# Fail example: backend server allocation reuses live ports incorrectly.
+def test_three_sequential_users_receive_distinct_backend_ports(
+    running_hub,
+    unique_name,
+):
+    users = [f"{unique_name}-{idx}" for idx in range(3)]
+
+    events = []
+    for username in users:
+        event, _ = _spawn_user(running_hub, username)
+        events.append(event)
+
+    ports = {event["port"] for event in events}
+    assert len(ports) == 3
+
+    for username in users:
+        _cleanup_user(username)
+
+
+# phase6-spawner-ext-23
+# Component: multi-user lifecycle.
+# Purpose: Verify three sequential users all become ready.
+# Pass example: every created user has a ready default server.
+# Fail example: later spawns fail after earlier users are running.
+def test_three_sequential_users_all_become_ready(running_hub, unique_name):
+    users = [f"{unique_name}-{idx}" for idx in range(3)]
+
+    models = []
+    for username in users:
+        _, user_model = _spawn_user(running_hub, username)
+        models.append(user_model)
+
+    assert all(model["servers"][""]["ready"] is True for model in models)
+
+    for username in users:
+        _cleanup_user(username)
+
+
+# phase6-spawner-ext-24
+# Component: multi-user lifecycle.
+# Purpose: Verify cleanup of one user does not stop another user's server.
+# Pass example: second user's server remains ready after first user cleanup.
+# Fail example: cleanup leaks across users.
+def test_cleanup_of_one_user_does_not_stop_another_user(
+    running_hub,
+    unique_name,
+):
+    first = f"{unique_name}-a"
+    second = f"{unique_name}-b"
+    _spawn_user(running_hub, first)
+    _spawn_user(running_hub, second)
+
+    _cleanup_user(first)
+    response = api_get(f"/hub/api/users/{second}")
+    second_model = response.json()
+
+    assert second_model["servers"][""]["ready"] is True
+    _cleanup_user(second)
+
+
+# phase6-spawner-ext-25
+# Component: lifecycle event ordering.
+# Purpose: Verify repeated lifecycle records start, stop, start ordering.
+# Pass example: event sequence contains start, stop, start for same user.
+# Fail example: event logging misses repeated lifecycle transitions.
+def test_repeated_lifecycle_records_start_stop_start_order(
+    running_hub,
+    unique_name,
+):
+    _spawn_user(running_hub, unique_name)
+    _stop_server(unique_name)
+    _start_server(unique_name)
+    _wait_for_server_ready(unique_name)
+
+    events = _events_for_user(running_hub, unique_name)
+    event_names = [event["event"] for event in events]
+
+    assert event_names[:3] == ["start", "stop", "start"]
+    _cleanup_user(unique_name)
+
+
+# phase6-spawner-ext-26
+# Component: lifecycle event ordering.
+# Purpose: Verify final cleanup records a stop event.
+# Pass example: the last event after cleanup is stop.
+# Fail example: cleanup deletes Hub state without reaching spawner.stop().
+def test_final_cleanup_records_stop_event(running_hub, unique_name):
+    _spawn_user(running_hub, unique_name)
+
+    _cleanup_user(unique_name)
+    events = _events_for_user(running_hub, unique_name)
+
+    assert events[-1]["event"] == "stop"
+
+
+# phase6-spawner-ext-27
+# Component: Hub process stability.
+# Purpose: Verify Hub survives multiple sequential spawns and stops.
+# Pass example: process.poll() remains None after repeated lifecycle operations.
+# Fail example: repeated spawner lifecycle crashes Hub.
+def test_hub_process_survives_multiple_spawns_and_stops(
+    running_hub,
+    unique_name,
+):
+    users = [f"{unique_name}-{idx}" for idx in range(3)]
+
+    for username in users:
+        _spawn_user(running_hub, username)
+
+    for username in users:
+        _cleanup_user(username)
+
+    assert running_hub["process"].poll() is None
+
+
+# phase6-spawner-ext-28
+# Component: route behavior after stop.
+# Purpose: Verify default user route no longer returns a successful backend route.
+# Pass example: route does not return HTTP 200 after stop.
+# Fail example: stopped backend remains available through Hub proxy.
+def test_default_user_route_changes_after_stop(running_hub, unique_name):
+    _spawn_user(running_hub, unique_name)
+    _stop_server(unique_name)
+
+    response = httpx.get(
+        f"{HUB_URL}/user/{unique_name}/",
+        timeout=5,
+        follow_redirects=False,
+    )
+
+    assert response.status_code != 200
+    delete_user(unique_name)
+
+
+# phase6-spawner-ext-29
+# Component: route behavior after stop.
+# Purpose: Verify named user route no longer returns a successful backend route.
+# Pass example: named route does not return HTTP 200 after stop.
+# Fail example: stopped named backend remains available through Hub proxy.
+def test_named_user_route_changes_after_stop(running_hub, unique_name):
+    _spawn_user(running_hub, unique_name, "named")
+    _stop_server(unique_name, "named")
+
+    response = httpx.get(
+        f"{HUB_URL}/user/{unique_name}/named/",
+        timeout=5,
+        follow_redirects=False,
+    )
+
+    assert response.status_code != 200
+    delete_user(unique_name)
+
+
+# phase6-spawner-ext-30
+# Component: spawner metadata consistency.
+# Purpose: Verify start events contain stable EGI initialization fields.
+# Pass example: event has token names, mount path, pvc_name, namespace.
+# Fail example: Hub-loaded EGISpawner misses expected initialization data.
+def test_spawner_start_event_contains_expected_egi_metadata(
+    running_hub,
+    unique_name,
+):
+    event, _ = _spawn_user(running_hub, unique_name)
+
+    assert event["token_secret_name"].startswith("access-token-")
+    assert event["token_secret_volume_name"].startswith("secret-")
+    assert event["token_mount_path"] == "/var/run/secrets/egi.eu/"
+    assert isinstance(event["pvc_name"], str)
+    assert event["pvc_name"]
+    assert isinstance(event["namespace"], str)
+    assert event["namespace"]
+    _cleanup_user(unique_name)

--- a/tests/phase6/test_hub_users.py
+++ b/tests/phase6/test_hub_users.py
@@ -1,0 +1,335 @@
+"""
+Phase 6 user and group API tests against a running JupyterHub process.
+"""
+
+import httpx
+
+from .conftest import (
+    HUB_URL,
+    api_get,
+    api_post,
+    create_group,
+    create_user,
+    delete_group,
+    delete_user,
+)
+
+
+# phase6-users-1
+# Component: Hub user API.
+# Purpose: Verify that the running Hub can create a user through its API.
+# Pass example: POST /hub/api/users/<name> returns HTTP 201 or 409.
+# Fail example: service token lacks admin user permissions.
+def test_running_hub_can_create_user(running_hub, unique_name):
+    response = create_user(unique_name)
+
+    assert response.status_code in {201, 409}
+    delete_user(unique_name)
+
+
+# phase6-users-2
+# Component: Hub user API.
+# Purpose: Verify that a created user can be read back through the API.
+# Pass example: GET /hub/api/users/<name> returns the same user name.
+# Fail example: user creation succeeds but read permissions are missing.
+def test_running_hub_can_read_created_user(running_hub, unique_name):
+    create_user(unique_name)
+
+    response = api_get(f"/hub/api/users/{unique_name}")
+
+    assert response.status_code == 200
+    assert response.json()["name"] == unique_name
+    delete_user(unique_name)
+
+
+# phase6-users-3
+# Component: Hub user API.
+# Purpose: Verify created users appear in the Hub user list.
+# Pass example: newly created user is present in /hub/api/users.
+# Fail example: list endpoint is not updated or token cannot list users.
+def test_running_hub_created_user_appears_in_user_list(
+    running_hub,
+    unique_name,
+):
+    create_user(unique_name)
+
+    response = api_get("/hub/api/users")
+    names = {user["name"] for user in response.json()}
+
+    assert unique_name in names
+    delete_user(unique_name)
+
+
+# phase6-users-4
+# Component: Hub user API.
+# Purpose: Verify deleting a user removes the user from direct lookup.
+# Pass example: GET after DELETE returns HTTP 404.
+# Fail example: delete call does not remove the user.
+def test_running_hub_can_delete_created_user(running_hub, unique_name):
+    create_user(unique_name)
+
+    delete_response = delete_user(unique_name)
+    read_response = api_get(f"/hub/api/users/{unique_name}")
+
+    assert delete_response.status_code in {204, 404}
+    assert read_response.status_code == 404
+
+
+# phase6-users-5
+# Component: Hub user API.
+# Purpose: Verify duplicate user creation is handled as a stable API response.
+# Pass example: second create returns HTTP 409 or compatible success.
+# Fail example: duplicate creation crashes Hub or returns a server error.
+def test_running_hub_duplicate_user_create_is_stable(running_hub, unique_name):
+    first = create_user(unique_name)
+    second = create_user(unique_name)
+
+    assert first.status_code in {201, 409}
+    assert second.status_code in {201, 409}
+    delete_user(unique_name)
+
+
+# phase6-users-6
+# Component: Hub user API.
+# Purpose: Verify missing users return a not-found response.
+# Pass example: GET for unknown user returns HTTP 404.
+# Fail example: Hub returns a server error for missing users.
+def test_running_hub_missing_user_returns_404(running_hub, unique_name):
+    response = api_get(f"/hub/api/users/{unique_name}")
+
+    assert response.status_code == 404
+
+
+# phase6-users-7
+# Component: Hub group API.
+# Purpose: Verify that the running Hub can create a group.
+# Pass example: POST /hub/api/groups/<name> returns HTTP 201 or 409.
+# Fail example: service token lacks group administration permissions.
+def test_running_hub_can_create_group(running_hub, unique_name):
+    response = create_group(unique_name)
+
+    assert response.status_code in {201, 409}
+    delete_group(unique_name)
+
+
+# phase6-users-8
+# Component: Hub group API.
+# Purpose: Verify a created group can be read through the group list.
+# Pass example: created group appears in /hub/api/groups.
+# Fail example: group creation succeeds but group list does not include it.
+def test_running_hub_created_group_appears_in_group_list(
+    running_hub,
+    unique_name,
+):
+    create_group(unique_name)
+
+    response = api_get("/hub/api/groups")
+    names = {group["name"] for group in response.json()}
+
+    assert unique_name in names
+    delete_group(unique_name)
+
+
+# phase6-users-9
+# Component: Hub group API.
+# Purpose: Verify deleting a group removes it from the group list.
+# Pass example: group name is absent after DELETE.
+# Fail example: delete call does not remove the group.
+def test_running_hub_can_delete_group(running_hub, unique_name):
+    create_group(unique_name)
+
+    delete_response = delete_group(unique_name)
+    list_response = api_get("/hub/api/groups")
+    names = {group["name"] for group in list_response.json()}
+
+    assert delete_response.status_code in {204, 404}
+    assert unique_name not in names
+
+
+# phase6-users-10
+# Component: Hub group API.
+# Purpose: Verify adding a user to a group works through the running Hub API.
+# Pass example: group model contains the added user's name.
+# Fail example: membership update is rejected or not persisted.
+def test_running_hub_can_add_user_to_group(running_hub, unique_name):
+    user_name = f"{unique_name}-user"
+    group_name = f"{unique_name}-group"
+    create_user(user_name)
+    create_group(group_name)
+
+    response = api_post(
+        f"/hub/api/groups/{group_name}/users",
+        json={"users": [user_name]},
+    )
+    assert response.status_code in {200, 201, 204}
+
+    group_response = api_get("/hub/api/groups")
+    groups = {group["name"]: group for group in group_response.json()}
+    users = groups[group_name].get("users", [])
+
+    assert user_name in users
+    delete_group(group_name)
+    delete_user(user_name)
+
+
+# phase6-users-11
+# Component: Hub group API.
+# Purpose: Verify adding a missing user to a group is rejected cleanly.
+# Pass example: Hub returns a 4xx response, not a 5xx server error.
+# Fail example: invalid membership update crashes Hub.
+def test_running_hub_rejects_missing_user_group_membership(
+    running_hub,
+    unique_name,
+):
+    group_name = f"{unique_name}-group"
+    missing_user = f"{unique_name}-missing"
+    create_group(group_name)
+
+    response = api_post(
+        f"/hub/api/groups/{group_name}/users",
+        json={"users": [missing_user]},
+    )
+
+    assert 400 <= response.status_code < 500
+    delete_group(group_name)
+
+
+# phase6-users-12
+# Component: Hub group API.
+# Purpose: Verify adding users to a missing group is rejected cleanly.
+# Pass example: Hub returns HTTP 404.
+# Fail example: invalid group membership update crashes Hub.
+def test_running_hub_rejects_membership_update_for_missing_group(
+    running_hub,
+    unique_name,
+):
+    user_name = f"{unique_name}-user"
+    group_name = f"{unique_name}-missing-group"
+    create_user(user_name)
+
+    response = api_post(
+        f"/hub/api/groups/{group_name}/users",
+        json={"users": [user_name]},
+    )
+
+    assert response.status_code == 404
+    delete_user(user_name)
+
+
+# phase6-users-13
+# Component: Hub user model.
+# Purpose: Verify user models include expected base fields.
+# Pass example: user model includes name, admin, groups, and servers keys.
+# Fail example: API model shape changes unexpectedly.
+def test_running_hub_user_model_contains_expected_fields(
+    running_hub,
+    unique_name,
+):
+    create_user(unique_name)
+
+    response = api_get(f"/hub/api/users/{unique_name}")
+    payload = response.json()
+
+    assert payload["name"] == unique_name
+    assert "admin" in payload
+    assert "groups" in payload
+    assert "servers" in payload
+    delete_user(unique_name)
+
+
+# phase6-users-14
+# Component: Hub group model.
+# Purpose: Verify group models include expected base fields.
+# Pass example: created group model includes name and users fields.
+# Fail example: API model shape changes unexpectedly.
+def test_running_hub_group_model_contains_expected_fields(
+    running_hub,
+    unique_name,
+):
+    create_group(unique_name)
+
+    response = api_get("/hub/api/groups")
+    groups = {group["name"]: group for group in response.json()}
+    payload = groups[unique_name]
+
+    assert payload["name"] == unique_name
+    assert "users" in payload
+    delete_group(unique_name)
+
+
+# phase6-users-15
+# Component: Hub API status handling.
+# Purpose: Verify deleting a missing user is stable and non-5xx.
+# Pass example: DELETE unknown user returns HTTP 404.
+# Fail example: Hub returns a server error.
+def test_running_hub_delete_missing_user_is_stable(running_hub, unique_name):
+    response = delete_user(unique_name)
+
+    assert response.status_code in {204, 404}
+
+
+# phase6-users-16
+# Component: Hub API status handling.
+# Purpose: Verify deleting a missing group is stable and non-5xx.
+# Pass example: DELETE unknown group returns HTTP 404.
+# Fail example: Hub returns a server error.
+def test_running_hub_delete_missing_group_is_stable(running_hub, unique_name):
+    response = delete_group(unique_name)
+
+    assert response.status_code in {204, 404}
+
+
+# phase6-users-17
+# Component: Hub API authorization.
+# Purpose: Verify user creation rejects missing credentials.
+# Pass example: POST /hub/api/users/<name> without token is rejected.
+# Fail example: anonymous clients can create users.
+def test_running_hub_user_create_requires_authentication(
+    running_hub,
+    unique_name,
+):
+    response = api_post(f"/hub/api/users/{unique_name}", token=False)
+
+    assert response.status_code in {403, 404}
+
+
+# phase6-users-18
+# Component: Hub API authorization.
+# Purpose: Verify group creation rejects missing credentials.
+# Pass example: POST /hub/api/groups/<name> without token is rejected.
+# Fail example: anonymous clients can create groups.
+def test_running_hub_group_create_requires_authentication(
+    running_hub,
+    unique_name,
+):
+    response = api_post(f"/hub/api/groups/{unique_name}", token=False)
+
+    assert response.status_code in {403, 404}
+
+
+# phase6-users-19
+# Component: Hub API authorization.
+# Purpose: Verify user deletion rejects missing credentials.
+# Pass example: DELETE /hub/api/users/<name> without token is rejected.
+# Fail example: anonymous clients can delete users.
+def test_running_hub_user_delete_requires_authentication(
+    running_hub,
+    unique_name,
+):
+    response = httpx.delete(f"{HUB_URL}/hub/api/users/{unique_name}", timeout=5)
+
+    assert response.status_code in {403, 404}
+
+
+# phase6-users-20
+# Component: Hub API authorization.
+# Purpose: Verify group deletion rejects missing credentials.
+# Pass example: DELETE /hub/api/groups/<name> without token is rejected.
+# Fail example: anonymous clients can delete groups.
+def test_running_hub_group_delete_requires_authentication(
+    running_hub,
+    unique_name,
+):
+    response = httpx.delete(f"{HUB_URL}/hub/api/groups/{unique_name}", timeout=5)
+
+    assert response.status_code in {403, 404}

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -130,7 +130,7 @@ def parse_args():
         "target",
         nargs="?",
         default="all",
-        choices=["phase1", "phase2", "phase3", "phase4", "phase5", "all"],
+        choices=["phase1", "phase2", "phase3", "phase4", "phase5", "phase6", "all"],
     )
 
     parser.add_argument("--list", action="store_true")

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -9,6 +9,7 @@ Usage:
     python tests/run_tests.py phase3
     python tests/run_tests.py phase4
     python tests/run_tests.py phase5
+    python tests/run_tests.py phase6
     python tests/run_tests.py all
 
 Optional flags:
@@ -56,6 +57,13 @@ PHASES = {
         "phase5-k3s/test_spawner_k3s_additional.py",
         "phase5-k3s/test_spawner_k3s_pods.py",
         "phase5-k3s/test_spawner_k3s_edge.py",
+    ],
+    "phase6": [
+        "phase6/test_hub_smoke.py",
+        "phase6/test_hub_users.py",
+        "phase6/test_hub_services.py",
+        "phase6/test_hub_spawner.py",
+        "phase6/test_hub_spawner_extended.py",
     ],
 }
 


### PR DESCRIPTION
## Summary

This PR adds a new Phase 6 test suite focused on running JupyterHub integration tests.

The new tests start a real JupyterHub process with a dedicated test configuration and validate:

- Hub API behavior
- Hub services and managed services
- User and group API operations
- Hub proxy routing
- Running-Hub integration with `EGISpawner`
- Spawner lifecycle behavior (`start`, `stop`, `poll`)
- Named server handling
- Multi-user isolation
- Cleanup behavior
- Authorization edge cases
- Runtime stability

The Phase 6 tests complement:

- Phase 1-4 unit and component tests
- Phase 5 k3s Kubernetes integration tests

Together they provide coverage for both:

- Kubernetes-facing integration behavior
- Real running-Hub lifecycle interaction

## Added files

- `tests/phase6_hub/jupyterhub_config.py`
- `tests/phase6_hub/conftest.py`
- `tests/phase6_hub/test_hub_smoke.py`
- `tests/phase6_hub/test_hub_users.py`
- `tests/phase6_hub/test_hub_services.py`
- `tests/phase6_hub/test_hub_spawner.py`
- `tests/phase6_hub/test_hub_spawner_extended.py`
- `.github/workflows/hub-tests.yml`

## Notes

- The running-Hub tests use a lightweight `EGISpawner` subclass for lifecycle validation without requiring real Kubernetes pod spawning.
- Kubernetes-level integration remains covered by the existing Phase 5 k3s tests.
- The tests were formatted and validated with the same linting/style tooling used in previous phases (`black`, `pyink`, `ruff`, `flake8`, `mypy`, `isort`).