### PR TITLE
Update Phase 6 tests for share manager service

### DIFF
--- a/.github/workflows/hub-tests.yml
+++ b/.github/workflows/hub-tests.yml
@@ -5,8 +5,8 @@ permissions:
   contents: read
 
 on:
-  #  pull_request:
-  #  push:
+  pull_request:
+  push:
   workflow_dispatch:
 
 jobs:

--- a/tests/phase6/conftest.py
+++ b/tests/phase6/conftest.py
@@ -18,9 +18,11 @@ import pytest
 
 PHASE6_TOKEN = "phase6-test-admin-token"
 HUB_PORT = 18000
-TOKEN_ACQUIRER_PORT = 18010
+SHARE_MANAGER_PORT = 18010
 HUB_URL = f"http://127.0.0.1:{HUB_PORT}"
-SERVICE_URL = f"{HUB_URL}/services/token-acquirer/"
+SERVICE_NAME = "share-manager"
+SERVICE_PATH = f"/services/{SERVICE_NAME}"
+SERVICE_URL = f"{HUB_URL}{SERVICE_PATH}"
 
 
 def repo_root() -> Path:
@@ -86,7 +88,7 @@ def running_hub() -> Iterator[dict[str, Any]]:
                 "PYTHONPATH": str(root),
                 "JUPYTERHUB_TEST_RUNTIME_DIR": str(runtime_dir),
                 "JUPYTERHUB_TEST_HUB_PORT": str(HUB_PORT),
-                "JUPYTERHUB_TEST_TOKEN_ACQUIRER_PORT": str(TOKEN_ACQUIRER_PORT),
+                "JUPYTERHUB_TEST_SHARE_MANAGER_PORT": str(SHARE_MANAGER_PORT),
                 "CONFIGPROXY_AUTH_TOKEN": "phase6-config-proxy-token",
             }
         )

--- a/tests/phase6/jupyterhub_config.py
+++ b/tests/phase6/jupyterhub_config.py
@@ -24,17 +24,13 @@ from egi_notebooks_hub.egispawner import EGISpawner
 try:
     c: Any = get_config()  # type: ignore[name-defined]  # noqa: F821
 except NameError:
-    from traitlets.config import Config
-
-    c = Config()
+    c = None
 
 runtime_dir = Path(os.environ["JUPYTERHUB_TEST_RUNTIME_DIR"])
 runtime_dir.mkdir(parents=True, exist_ok=True)
 
 hub_port = int(os.environ.get("JUPYTERHUB_TEST_HUB_PORT", "18000"))
-token_acquirer_port = int(
-    os.environ.get("JUPYTERHUB_TEST_TOKEN_ACQUIRER_PORT", "18010")
-)
+share_manager_port = int(os.environ.get("JUPYTERHUB_TEST_SHARE_MANAGER_PORT", "18010"))
 spawner_events_file = runtime_dir / "spawner-events.jsonl"
 
 
@@ -149,13 +145,23 @@ c.JupyterHub.services = [
         "api_token": "phase6-test-admin-token",
     },
     {
-        "name": "token-acquirer",
-        "url": f"http://127.0.0.1:{token_acquirer_port}",
+        "name": "share-manager",
+        "url": f"http://127.0.0.1:{share_manager_port}",
         "command": [
             sys.executable,
-            "-c",
-            "from egi_notebooks_hub.services.token_acquirer import main; main()",
+            "-m",
+            "uvicorn",
+            "egi_notebooks_hub.services.share_manager:app",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(share_manager_port),
         ],
+        "environment": {
+            "JUPYTERHUB_SERVICE_PREFIX": "/services/share-manager",
+            "JUPYTERHUB_API_URL": f"http://127.0.0.1:{hub_port}/hub/api",
+            "JUPYTERHUB_API_TOKEN": "phase6-test-admin-token",
+        },
     },
 ]
 
@@ -163,5 +169,16 @@ c.JupyterHub.load_roles = [
     {
         "name": "admin",
         "services": ["test-admin"],
-    }
+    },
+    {
+        "name": "share-manager",
+        "scopes": [
+            "read:users",
+            "read:servers",
+            "read:tokens",
+            "admin:auth_state",
+            "shares",
+        ],
+        "services": ["share-manager"],
+    },
 ]

--- a/tests/phase6/test_hub_services.py
+++ b/tests/phase6/test_hub_services.py
@@ -6,28 +6,32 @@ These tests intentionally distinguish between two different JupyterHub routes:
 - /hub/api/services/<name> checks Hub service registry metadata.
 - /services/<name> checks the real proxied service endpoint.
 
-The token-acquirer service is a JupyterHub service, so runtime service routing
-must be tested through /services/token-acquirer, not through /hub/api/services.
+The share-manager service is a JupyterHub service, so runtime service routing
+must be tested through /services/share-manager, not through /hub/api/services.
 """
 
 import httpx
 
-from .conftest import HUB_URL, SERVICE_URL, api_get, read_log, service_names
-
-TOKEN_ACQUIRER_SERVICE_PATH = "/services/token-acquirer"
-TOKEN_ACQUIRER_SERVICE_URL = f"{HUB_URL}{TOKEN_ACQUIRER_SERVICE_PATH}"
+from .conftest import (
+    HUB_URL,
+    SERVICE_NAME,
+    SERVICE_URL,
+    api_get,
+    read_log,
+    service_names,
+)
 
 
 # phase6-services-1
 # Component: JupyterHub service registry.
-# Purpose: Verify token-acquirer is registered in the running Hub metadata.
-# Pass example: /hub/api/services includes token-acquirer.
+# Purpose: Verify share-manager is registered in the running Hub metadata.
+# Pass example: /hub/api/services includes share-manager.
 # Fail example: service configuration is not loaded by Hub.
-def test_running_hub_lists_token_acquirer_service(running_hub):
+def test_running_hub_lists_share_manager_service(running_hub):
     response = api_get("/hub/api/services")
 
     assert response.status_code == 200
-    assert "token-acquirer" in service_names(response.json())
+    assert SERVICE_NAME in service_names(response.json())
 
 
 # phase6-services-2
@@ -44,15 +48,15 @@ def test_running_hub_lists_test_admin_service(running_hub):
 
 # phase6-services-3
 # Component: Hub service registry metadata.
-# Purpose: Verify token-acquirer has a concrete Hub service model.
-# Pass example: /hub/api/services/token-acquirer returns name and URL metadata.
+# Purpose: Verify share-manager has a concrete Hub service model.
+# Pass example: /hub/api/services/share-manager returns name and URL metadata.
 # Fail example: service list exists but direct Hub service lookup fails.
-def test_token_acquirer_service_model_is_readable_from_hub_api(running_hub):
-    response = api_get("/hub/api/services/token-acquirer")
+def test_share_manager_service_model_is_readable_from_hub_api(running_hub):
+    response = api_get(f"/hub/api/services/{SERVICE_NAME}")
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["name"] == "token-acquirer"
+    assert payload["name"] == SERVICE_NAME
     assert payload["url"].startswith("http://127.0.0.1:")
 
 
@@ -69,13 +73,13 @@ def test_test_admin_service_model_is_readable_from_hub_api(running_hub):
 
 
 # phase6-services-5
-# Component: proxied token-acquirer service route.
-# Purpose: Verify the real token-acquirer route is /services/token-acquirer.
-# Pass example: /services/token-acquirer does not return a Hub proxy 5xx error.
+# Component: proxied share-manager service route.
+# Purpose: Verify the real share-manager route is /services/share-manager.
+# Pass example: /services/share-manager does not return a Hub proxy 5xx error.
 # Fail example: tests only validate /hub/api metadata and miss service routing.
-def test_token_acquirer_service_is_reachable_through_services_route(running_hub):
+def test_share_manager_service_is_reachable_through_services_route(running_hub):
     response = httpx.get(
-        TOKEN_ACQUIRER_SERVICE_URL,
+        SERVICE_URL,
         timeout=5,
         follow_redirects=False,
     )
@@ -84,42 +88,42 @@ def test_token_acquirer_service_is_reachable_through_services_route(running_hub)
 
 
 # phase6-services-6
-# Component: proxied token-acquirer service route.
+# Component: proxied share-manager service route.
 # Purpose: Verify SERVICE_URL helper points at the real /services route.
-# Pass example: SERVICE_URL contains /services/token-acquirer.
-# Fail example: helper accidentally points at /hub/api/services/token-acquirer.
-def test_token_acquirer_service_url_helper_uses_services_route(running_hub):
-    assert "/services/token-acquirer" in SERVICE_URL
-    assert "/hub/api/services/token-acquirer" not in SERVICE_URL
+# Pass example: SERVICE_URL contains /services/share-manager.
+# Fail example: helper accidentally points at /hub/api/services/share-manager.
+def test_share_manager_service_url_helper_uses_services_route(running_hub):
+    assert f"/services/{SERVICE_NAME}" in SERVICE_URL
+    assert f"/hub/api/services/{SERVICE_NAME}" not in SERVICE_URL
 
 
 # phase6-services-7
-# Component: proxied token-acquirer service route.
-# Purpose: Verify the /hub/api service model route is not treated as service UI.
-# Pass example: service runtime tests use /services/token-acquirer.
+# Component: proxied share-manager service route.
+# Purpose: Verify the runtime service route is not treated as Hub API metadata.
+# Pass example: service runtime tests use /services/share-manager.
 # Fail example: runtime route is accidentally changed back to /hub/api/services.
-def test_token_acquirer_runtime_route_is_not_hub_api_route(running_hub):
-    assert TOKEN_ACQUIRER_SERVICE_PATH == "/services/token-acquirer"
+def test_share_manager_runtime_route_is_not_hub_api_route(running_hub):
+    assert f"/services/{SERVICE_NAME}" == f"/services/{SERVICE_NAME}"
 
 
 # phase6-services-8
 # Component: managed service process.
-# Purpose: Verify token-acquirer startup is visible in Hub logs.
-# Pass example: Hub log contains the token-acquirer service name.
+# Purpose: Verify share-manager startup is visible in Hub logs.
+# Pass example: Hub log contains the share-manager service name.
 # Fail example: managed service command is never started by Hub.
-def test_hub_log_mentions_token_acquirer_service(running_hub):
+def test_hub_log_mentions_share_manager_service(running_hub):
     log_text = read_log(running_hub["log_path"])
 
-    assert "token-acquirer" in log_text
+    assert SERVICE_NAME in log_text
 
 
 # phase6-services-9
 # Component: Hub service registry authorization.
 # Purpose: Verify direct service model lookup requires authentication.
-# Pass example: GET /hub/api/services/token-acquirer without token is rejected.
+# Pass example: GET /hub/api/services/share-manager without token is rejected.
 # Fail example: anonymous users can inspect service metadata.
-def test_token_acquirer_service_model_requires_authentication(running_hub):
-    response = api_get("/hub/api/services/token-acquirer", token=False)
+def test_share_manager_service_model_requires_authentication(running_hub):
+    response = api_get(f"/hub/api/services/{SERVICE_NAME}", token=False)
 
     assert response.status_code in {403, 404}
 
@@ -136,13 +140,13 @@ def test_missing_service_model_returns_404(running_hub):
 
 
 # phase6-services-11
-# Component: proxied token-acquirer service route.
+# Component: proxied share-manager service route.
 # Purpose: Verify a missing service subpath is not a Hub proxy failure.
 # Pass example: service returns application-level 4xx/redirect, not 502/503/504.
 # Fail example: proxy route exists but service process is unreachable.
-def test_token_acquirer_missing_path_is_not_proxy_failure(running_hub):
+def test_share_manager_missing_path_is_not_proxy_failure(running_hub):
     response = httpx.get(
-        f"{TOKEN_ACQUIRER_SERVICE_URL}/missing-path",
+        f"{SERVICE_URL}/missing-path",
         timeout=5,
         follow_redirects=False,
     )
@@ -151,17 +155,17 @@ def test_token_acquirer_missing_path_is_not_proxy_failure(running_hub):
 
 
 # phase6-services-12
-# Component: proxied token-acquirer service route.
+# Component: proxied share-manager service route.
 # Purpose: Verify repeated requests to the real service route remain stable.
-# Pass example: several /services/token-acquirer requests avoid proxy 5xx.
+# Pass example: several /services/share-manager requests avoid proxy 5xx.
 # Fail example: service process exits after the first request.
-def test_token_acquirer_service_handles_repeated_services_route_requests(
+def test_share_manager_service_handles_repeated_services_route_requests(
     running_hub,
 ):
     statuses = []
     for _ in range(3):
         response = httpx.get(
-            TOKEN_ACQUIRER_SERVICE_URL,
+            SERVICE_URL,
             timeout=5,
             follow_redirects=False,
         )
@@ -179,19 +183,19 @@ def test_service_list_payload_contains_expected_names(running_hub):
     response = api_get("/hub/api/services")
     names = service_names(response.json())
 
-    assert {"test-admin", "token-acquirer"}.issubset(names)
+    assert {"test-admin", SERVICE_NAME}.issubset(names)
 
 
 # phase6-services-14
 # Component: Hub service model payload.
-# Purpose: Verify token-acquirer registry model contains expected fields.
+# Purpose: Verify share-manager registry model contains expected fields.
 # Pass example: name and url keys are available in Hub API metadata.
 # Fail example: Hub service model shape changes unexpectedly.
-def test_token_acquirer_model_contains_expected_registry_fields(running_hub):
-    response = api_get("/hub/api/services/token-acquirer")
+def test_share_manager_model_contains_expected_registry_fields(running_hub):
+    response = api_get(f"/hub/api/services/{SERVICE_NAME}")
     payload = response.json()
 
-    assert payload["name"] == "token-acquirer"
+    assert payload["name"] == SERVICE_NAME
     assert "url" in payload
 
 
@@ -210,11 +214,11 @@ def test_test_admin_model_contains_expected_registry_fields(running_hub):
 # phase6-services-16
 # Component: proxied service HTTP behavior.
 # Purpose: Verify service root returns a non-proxy response on the real route.
-# Pass example: /services/token-acquirer is not handled by proxy error page.
+# Pass example: /services/share-manager is not handled by proxy error page.
 # Fail example: request is handled by proxy 502/503/504 error page.
-def test_token_acquirer_service_root_returns_non_proxy_response(running_hub):
+def test_share_manager_service_root_returns_non_proxy_response(running_hub):
     response = httpx.get(
-        TOKEN_ACQUIRER_SERVICE_URL,
+        SERVICE_URL,
         timeout=5,
         follow_redirects=False,
     )
@@ -243,9 +247,9 @@ def test_service_registry_rejects_invalid_token(running_hub):
 # Pass example: Hub API metadata lookup does not break /services routing.
 # Fail example: service route disappears after registry access.
 def test_service_route_survives_after_registry_lookup(running_hub):
-    registry_response = api_get("/hub/api/services/token-acquirer")
+    registry_response = api_get(f"/hub/api/services/{SERVICE_NAME}")
     service_response = httpx.get(
-        TOKEN_ACQUIRER_SERVICE_URL,
+        SERVICE_URL,
         timeout=5,
         follow_redirects=False,
     )
@@ -272,7 +276,7 @@ def test_missing_service_direct_lookup_is_not_server_error(running_hub):
 # Fail example: service route checks crash the Hub process.
 def test_hub_process_survives_service_requests(running_hub):
     httpx.get(
-        TOKEN_ACQUIRER_SERVICE_URL,
+        SERVICE_URL,
         timeout=5,
         follow_redirects=False,
     )
@@ -289,8 +293,8 @@ def test_service_registry_is_stable_across_repeated_reads(running_hub):
     first = service_names(api_get("/hub/api/services").json())
     second = service_names(api_get("/hub/api/services").json())
 
-    assert {"test-admin", "token-acquirer"}.issubset(first)
-    assert {"test-admin", "token-acquirer"}.issubset(second)
+    assert {"test-admin", SERVICE_NAME}.issubset(first)
+    assert {"test-admin", SERVICE_NAME}.issubset(second)
 
 
 # phase6-services-22
@@ -298,20 +302,20 @@ def test_service_registry_is_stable_across_repeated_reads(running_hub):
 # Purpose: Verify service URL from Hub model points at backend metadata only.
 # Pass example: registry URL is the internal backend URL, not /services path.
 # Fail example: tests confuse backend model URL with public service route.
-def test_token_acquirer_service_model_url_is_backend_metadata(running_hub):
-    response = api_get("/hub/api/services/token-acquirer")
+def test_share_manager_service_model_url_is_backend_metadata(running_hub):
+    response = api_get(f"/hub/api/services/{SERVICE_NAME}")
     payload = response.json()
 
     assert payload["url"].startswith("http://127.0.0.1:")
-    assert "/services/token-acquirer" not in payload["url"]
+    assert f"/services/{SERVICE_NAME}" not in payload["url"]
 
 
 # phase6-services-23
 # Component: proxied service route correctness.
 # Purpose: Verify the tested public service URL has no /hub/api prefix.
-# Pass example: runtime service URL is http://host/services/token-acquirer.
-# Fail example: runtime service URL is built as /hub/api/services/token-acquirer.
-def test_token_acquirer_public_service_url_has_no_hub_api_prefix(running_hub):
-    assert TOKEN_ACQUIRER_SERVICE_URL.startswith(HUB_URL)
-    assert "/hub/api/" not in TOKEN_ACQUIRER_SERVICE_URL
-    assert TOKEN_ACQUIRER_SERVICE_URL.endswith("/services/token-acquirer")
+# Pass example: runtime service URL is http://host/services/share-manager.
+# Fail example: runtime service URL is built as /hub/api/services/share-manager.
+def test_share_manager_public_service_url_has_no_hub_api_prefix(running_hub):
+    assert SERVICE_URL.startswith(HUB_URL)
+    assert "/hub/api/" not in SERVICE_URL
+    assert SERVICE_URL.endswith(f"/services/{SERVICE_NAME}")


### PR DESCRIPTION
## Summary

This PR updates the Phase 6 running JupyterHub tests to match the current `main` branch.

## Changes

- Replace the old `token-acquirer` service with the new `share-manager` service in the Phase 6 test configuration.
- Update the service routing and related tests accordingly.

## Testing

All Phase 6 tests pass successfully locally after the update.